### PR TITLE
Post 생성 API 구현 #14

### DIFF
--- a/src/main/java/dev/backlog/domain/hashtag/infrastructure/persistence/HashtagRepository.java
+++ b/src/main/java/dev/backlog/domain/hashtag/infrastructure/persistence/HashtagRepository.java
@@ -3,5 +3,10 @@ package dev.backlog.domain.hashtag.infrastructure.persistence;
 import dev.backlog.domain.hashtag.model.Hashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+    Optional<Hashtag> findByName(String hashtag);
+
 }

--- a/src/main/java/dev/backlog/domain/hashtag/model/Hashtag.java
+++ b/src/main/java/dev/backlog/domain/hashtag/model/Hashtag.java
@@ -24,4 +24,8 @@ public class Hashtag {
     @Column(nullable = false, length = 20)
     private String name;
 
+    public Hashtag(String name) {
+        this.name = name;
+    }
+
 }

--- a/src/main/java/dev/backlog/domain/post/api/PostController.java
+++ b/src/main/java/dev/backlog/domain/post/api/PostController.java
@@ -1,0 +1,29 @@
+package dev.backlog.domain.post.api;
+
+
+import dev.backlog.domain.post.dto.PostCreateRequest;
+import dev.backlog.domain.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestBody PostCreateRequest request, Long userId) {
+        Long postId = postService.create(request, userId);
+
+        return ResponseEntity.created(URI.create("/posts/" + postId)).build();
+    }
+
+}

--- a/src/main/java/dev/backlog/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/dev/backlog/domain/post/dto/PostCreateRequest.java
@@ -10,7 +10,7 @@ public record PostCreateRequest(
         String series,
         String title,
         String content,
-        Set<String> hashTags,
+        Set<String> hashtags,
         String summary,
         boolean isPublic,
         String thumbnailImage,

--- a/src/main/java/dev/backlog/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/dev/backlog/domain/post/dto/PostCreateRequest.java
@@ -1,0 +1,33 @@
+package dev.backlog.domain.post.dto;
+
+import dev.backlog.domain.post.model.Post;
+import dev.backlog.domain.series.model.Series;
+import dev.backlog.domain.user.model.User;
+
+import java.util.Set;
+
+public record PostCreateRequest(
+        String series,
+        String title,
+        String content,
+        Set<String> hashTags,
+        String summary,
+        boolean isPublic,
+        String thumbnailImage,
+        String path
+) {
+
+    public Post toEntity(Series series, User user) {
+        return Post.builder()
+                .series(series)
+                .title(this.title)
+                .user(user)
+                .content(this.content)
+                .summary(this.summary)
+                .isPublic(this.isPublic)
+                .thumbnailImage(this.thumbnailImage)
+                .path(this.path)
+                .build();
+    }
+
+}

--- a/src/main/java/dev/backlog/domain/post/model/Post.java
+++ b/src/main/java/dev/backlog/domain/post/model/Post.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,7 +41,7 @@ public class Post {
     private String content;
 
     @Column(length = 100)
-    private String introduction;
+    private String summary;
 
     @Column(nullable = false)
     private Boolean isPublic;

--- a/src/main/java/dev/backlog/domain/post/model/Post.java
+++ b/src/main/java/dev/backlog/domain/post/model/Post.java
@@ -51,4 +51,29 @@ public class Post {
 
     @Column(nullable = false)
     private String path;
+
+    @Builder
+    private Post(Series series,
+                 User user,
+                 String title,
+                 String content,
+                 String summary,
+                 Boolean isPublic,
+                 String thumbnailImage,
+                 String path
+    ) {
+        this.series = series;
+        this.user = user;
+        this.title = title;
+        this.content = content;
+        this.summary = summary;
+        this.isPublic = isPublic;
+        this.thumbnailImage = thumbnailImage;
+        this.path = path;
+    }
+
+    public String getWriterName() {
+        return this.user.getNickname();
+    }
+
 }

--- a/src/main/java/dev/backlog/domain/post/service/PostService.java
+++ b/src/main/java/dev/backlog/domain/post/service/PostService.java
@@ -5,7 +5,6 @@ import dev.backlog.domain.post.dto.PostResponseDto;
 import dev.backlog.domain.post.infrastructure.persistence.PostRepository;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.tmp.UserDetails;
-import dev.backlog.domain.posthashtag.model.PostHashtag;
 import dev.backlog.domain.posthashtag.service.PostHashtagService;
 import dev.backlog.domain.series.infrastructure.persistence.SeriesRepository;
 import dev.backlog.domain.series.model.Series;
@@ -37,12 +36,12 @@ public class PostService {
 
         Series series = seriesRepository.findByUserAndName(user, request.series())
                 .orElse(null);
-
         Post post = request.toEntity(series, user);
         Post savedPost = postRepository.save(post);
 
-
-
+        if (request.hashtags() != null) {
+            postHashtagService.save(request.hashtags(), post);
+        }
         return savedPost.getId();
     }
 

--- a/src/main/java/dev/backlog/domain/post/service/PostService.java
+++ b/src/main/java/dev/backlog/domain/post/service/PostService.java
@@ -1,8 +1,16 @@
 package dev.backlog.domain.post.service;
 
+import dev.backlog.domain.post.dto.PostCreateRequest;
 import dev.backlog.domain.post.dto.PostResponseDto;
 import dev.backlog.domain.post.infrastructure.persistence.PostRepository;
+import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.tmp.UserDetails;
+import dev.backlog.domain.posthashtag.model.PostHashtag;
+import dev.backlog.domain.posthashtag.service.PostHashtagService;
+import dev.backlog.domain.series.infrastructure.persistence.SeriesRepository;
+import dev.backlog.domain.series.model.Series;
+import dev.backlog.domain.user.infrastructure.persistence.UserRepository;
+import dev.backlog.domain.user.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,10 +20,30 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PostService {
 
+    private final PostHashtagService postHashtagService;
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final SeriesRepository seriesRepository;
 
     @Transactional
     public PostResponseDto findPostById(UserDetails userDetails, Long postId) {
         return null;
     }
+
+    @Transactional
+    public Long create(PostCreateRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        Series series = seriesRepository.findByUserAndName(user, request.series())
+                .orElse(null);
+
+        Post post = request.toEntity(series, user);
+        Post savedPost = postRepository.save(post);
+
+
+
+        return savedPost.getId();
+    }
+
 }

--- a/src/main/java/dev/backlog/domain/posthashtag/model/PostHashtag.java
+++ b/src/main/java/dev/backlog/domain/posthashtag/model/PostHashtag.java
@@ -34,4 +34,9 @@ public class PostHashtag {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    public PostHashtag(Hashtag hashtag, Post post) {
+        this.hashtag = hashtag;
+        this.post = post;
+    }
+
 }

--- a/src/main/java/dev/backlog/domain/posthashtag/service/PostHashtagService.java
+++ b/src/main/java/dev/backlog/domain/posthashtag/service/PostHashtagService.java
@@ -1,0 +1,41 @@
+package dev.backlog.domain.posthashtag.service;
+
+import dev.backlog.domain.hashtag.infrastructure.persistence.HashtagRepository;
+import dev.backlog.domain.hashtag.model.Hashtag;
+import dev.backlog.domain.post.model.Post;
+import dev.backlog.domain.posthashtag.infrastructure.persistence.PostHashtagRepository;
+import dev.backlog.domain.posthashtag.model.PostHashtag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class PostHashtagService {
+
+    private final PostHashtagRepository postHashtagRepository;
+    private final HashtagRepository hashtagRepository;
+
+    public void save(Set<String> names, Post post) {
+        List<Hashtag> hashtags = findHashtags(names);
+        List<PostHashtag> postHashtags = hashtags.stream()
+                .map(hashtag -> new PostHashtag(hashtag, post))
+                .toList();
+
+        postHashtagRepository.saveAll(postHashtags);
+    }
+
+    private List<Hashtag> findHashtags(Set<String> hashtags) {
+        return hashtags.stream()
+                .map(this::findOrSave)
+                .toList();
+    }
+
+    private Hashtag findOrSave(String hashtag) {
+        return hashtagRepository.findByName(hashtag)
+                .orElseGet(() -> hashtagRepository.save(new Hashtag(hashtag)));
+    }
+
+}

--- a/src/main/java/dev/backlog/domain/posthashtag/service/PostHashtagService.java
+++ b/src/main/java/dev/backlog/domain/posthashtag/service/PostHashtagService.java
@@ -29,11 +29,11 @@ public class PostHashtagService {
 
     private List<Hashtag> findHashtags(Set<String> hashtags) {
         return hashtags.stream()
-                .map(this::findOrSave)
+                .map(this::findOrCreate)
                 .toList();
     }
 
-    private Hashtag findOrSave(String hashtag) {
+    private Hashtag findOrCreate(String hashtag) {
         return hashtagRepository.findByName(hashtag)
                 .orElseGet(() -> hashtagRepository.save(new Hashtag(hashtag)));
     }

--- a/src/main/java/dev/backlog/domain/series/infrastructure/persistence/SeriesRepository.java
+++ b/src/main/java/dev/backlog/domain/series/infrastructure/persistence/SeriesRepository.java
@@ -1,7 +1,12 @@
 package dev.backlog.domain.series.infrastructure.persistence;
 
 import dev.backlog.domain.series.model.Series;
+import dev.backlog.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SeriesRepository extends JpaRepository<Series, Long> {
+
+    Optional<Series> findByUserAndName(User user, String name);
 }

--- a/src/main/java/dev/backlog/domain/series/model/Series.java
+++ b/src/main/java/dev/backlog/domain/series/model/Series.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,4 +31,10 @@ public class Series {
 
     @Column(nullable = false, length = 20)
     private String name;
+
+    @Builder
+    private Series(User user, String name) {
+        this.user = user;
+        this.name = name;
+    }
 }

--- a/src/main/java/dev/backlog/domain/user/model/User.java
+++ b/src/main/java/dev/backlog/domain/user/model/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -51,6 +52,24 @@ public class User {
     @Column(nullable = false)
     private LocalDate deletedDate;
 
+    @Builder
+    private User(OAuthProvider oauthProvider,
+                 String oauthProviderId,
+                 String nickname, Email email,
+                 String profileImage,
+                 String introduction,
+                 String blogTitle
+    ) {
+        this.oauthProvider = oauthProvider;
+        this.oauthProviderId = oauthProviderId;
+        this.nickname = nickname;
+        this.email = email;
+        this.profileImage = profileImage;
+        this.introduction = introduction;
+        this.blogTitle = blogTitle;
+        this.deletedDate = LocalDate.MAX;
+    }
+
     public User(String nickname, Email email, String profileImage, String blogTitle, OAuthProvider oauthProvider) {
         this.nickname = nickname;
         this.email = email;
@@ -58,4 +77,5 @@ public class User {
         this.blogTitle = blogTitle;
         this.oauthProvider = oauthProvider;
     }
+
 }

--- a/src/test/java/dev/backlog/domain/hashtag/infrastructure/persistence/HashtagRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/hashtag/infrastructure/persistence/HashtagRepositoryTest.java
@@ -1,0 +1,29 @@
+package dev.backlog.domain.hashtag.infrastructure.persistence;
+
+import dev.backlog.domain.hashtag.model.Hashtag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class HashtagRepositoryTest {
+
+    @Autowired
+    private HashtagRepository hashtagRepository;
+
+    @DisplayName("해쉬태그의 이름으로 해쉬태그를 찾을 수 있다.")
+    @Test
+    void findByNameTest() {
+        String 해쉬태그 = "해쉬태그";
+        Hashtag hashtag = new Hashtag(해쉬태그);
+
+        Hashtag savedHashtag = hashtagRepository.save(hashtag);
+        Hashtag foundHashtag = hashtagRepository.findByName(해쉬태그).get();
+
+        assertThat(foundHashtag).isEqualTo(savedHashtag);
+    }
+
+}

--- a/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
+++ b/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
@@ -3,6 +3,7 @@ package dev.backlog.domain.post.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.backlog.domain.post.dto.PostCreateRequest;
 import dev.backlog.domain.post.service.PostService;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -28,6 +29,7 @@ public class PostControllerTest {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
+    @DisplayName("게시물 생성 요청을 받아 처리 후 201 코드를 반환하고 게시물 조회 URI를 반환한다.")
     @Test
     public void testCreate() throws Exception {
         Long userId = 1L;

--- a/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
+++ b/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
@@ -1,0 +1,55 @@
+package dev.backlog.domain.post.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.backlog.domain.post.dto.PostCreateRequest;
+import dev.backlog.domain.post.service.PostService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PostController.class)
+public class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PostService postService;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testCreate() throws Exception {
+        Long userId = 1L;
+        Long postId = 2L;
+        PostCreateRequest request = new PostCreateRequest(
+                "series",
+                "제목", "내용",
+                null,
+                "요약",
+                true,
+                "썸네일",
+                "경로"
+        );
+        when(postService.create(any(PostCreateRequest.class), eq(userId)))
+                .thenReturn(postId);
+
+        mockMvc.perform(post("/api/posts")
+                        .param("userId", userId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/posts/" + postId));
+    }
+
+}

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -5,7 +5,6 @@ import dev.backlog.domain.user.infrastructure.persistence.UserRepository;
 import dev.backlog.domain.user.model.Email;
 import dev.backlog.domain.user.model.User;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -1,0 +1,52 @@
+package dev.backlog.domain.post.service;
+
+import dev.backlog.domain.post.dto.PostCreateRequest;
+import dev.backlog.domain.user.infrastructure.persistence.UserRepository;
+import dev.backlog.domain.user.model.Email;
+import dev.backlog.domain.user.model.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static dev.backlog.domain.user.model.OAuthProvider.KAKAO;
+
+@SpringBootTest
+class PostServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PostService postService;
+
+    @DisplayName("포스트 생성요청과 유저의 아이디를 받아 게시물을 저장할 수 있다.")
+    @Test
+    void createTest() {
+        User user = User.builder()
+                .oauthProvider(KAKAO)
+                .oauthProviderId("test")
+                .nickname("test")
+                .email(new Email("test@example.com"))
+                .profileImage("image")
+                .blogTitle("blogTitle")
+                .build();
+        User savedUser = userRepository.save(user);
+
+        PostCreateRequest request = new PostCreateRequest(
+                null,
+                "제목",
+                "내용",
+                null,
+                "요약",
+                true,
+                "url",
+                "/path"
+        );
+
+        Long postId = postService.create(request, savedUser.getId());
+        Assertions.assertThat(postId).isOne();
+    }
+
+}

--- a/src/test/java/dev/backlog/domain/series/infrastructure/persistence/SeriesRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/series/infrastructure/persistence/SeriesRepositoryTest.java
@@ -1,0 +1,46 @@
+package dev.backlog.domain.series.infrastructure.persistence;
+
+import dev.backlog.domain.series.model.Series;
+import dev.backlog.domain.user.infrastructure.persistence.UserRepository;
+import dev.backlog.domain.user.model.Email;
+import dev.backlog.domain.user.model.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static dev.backlog.domain.user.model.OAuthProvider.KAKAO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class SeriesRepositoryTest {
+
+    @Autowired
+    SeriesRepository seriesRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("유저와 시리즈의 이름으로 시리즈를 조회할 수 있다.")
+    @Test
+    void findByUserAndNameTest() {
+        User user = User.builder()
+                .oauthProvider(KAKAO)
+                .oauthProviderId("test")
+                .nickname("test")
+                .email(new Email("test@example.com"))
+                .profileImage("image")
+                .blogTitle("blogTitle")
+                .build();
+        User savedUser = userRepository.save(user);
+
+        Series series = Series.builder()
+                .user(savedUser)
+                .name("시리즈")
+                .build();
+        Series savedSeries = seriesRepository.save(series);
+
+        Series foundSeries = seriesRepository.findByUserAndName(savedUser, "시리즈").get();
+        assertThat(savedSeries).isEqualTo(foundSeries);
+    }
+
+}

--- a/src/test/java/dev/backlog/domain/series/infrastructure/persistence/SeriesRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/series/infrastructure/persistence/SeriesRepositoryTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SeriesRepositoryTest {
 
     @Autowired
-    SeriesRepository seriesRepository;
+    private SeriesRepository seriesRepository;
     @Autowired
     private UserRepository userRepository;
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,30 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MYSQL
+    username: sa
+    password:
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+
+    properties:
+      hibernate:
+        format_sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 1234
+      password: test
+jwt:
+  secret-key: yo0ToXEwMlNd32XqxRGKx8hsHWIk6P0u2/xlpny1vFw
+  access-token-expire-time: 1000
+  refresh-token-expire-time: 10000
+
+oauth:
+  kakao:
+    client-id: client-id
+    url:
+      auth: https://kauth.kakao.com
+      api: https://kapi.kakao.com


### PR DESCRIPTION
## 📄 Summary
> 이슈 번호 14번꺼 구현해놓고.. 커밋메시지에 #15로 했네요 죄송합니다 ㅠㅠ
- 테스트코드랑 프로덕션 코드 모두 짜서 올려봤습니다. More에 고민했던 부분 함께 남기겠습니다.

## 🍸 More
- Post - PostHashtag가 현재 단방향인데 양방향으로 해서 Post에서 해쉬태그를 바로 조회할 수 있는게 좋을까?
- `PostHashtag` 같은 필드가 적은 클래스는 빌더패턴을 적용하지 않았는데. 이 경우에도 빌더로 통일하는게 좋을까요?
- 현재는 컨트롤러에서 Long userId로 받는다고 가정을 했는데 토큰 파싱을 앞단에서 어떻게 해줄건지 알려주면 좋을거같습니다.
