### PR TITLE
게시물 삭제 API 개발

### DIFF
--- a/src/main/java/dev/backlog/domain/post/api/PostController.java
+++ b/src/main/java/dev/backlog/domain/post/api/PostController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,6 +64,13 @@ public class PostController {
                                            @RequestBody PostUpdateRequest request,
                                            Long userId) {
         postService.updatePost(request, postId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId,
+                                           Long userId) {
+        postService.deletePost(postId, userId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/dev/backlog/domain/post/model/Post.java
+++ b/src/main/java/dev/backlog/domain/post/model/Post.java
@@ -90,6 +90,12 @@ public class Post extends BaseEntity {
         this.viewCount = viewCount;
     }
 
+    public void verifyPostOwner(User user) {
+        if (!this.user.equals(user)) {
+            throw new IllegalArgumentException("접근 권한이 없습니다.");
+        }
+    }
+
     public void updateTitle(String title) {
         this.title = title;
     }

--- a/src/main/java/dev/backlog/domain/post/service/PostService.java
+++ b/src/main/java/dev/backlog/domain/post/service/PostService.java
@@ -107,6 +107,17 @@ public class PostService {
         }
     }
 
+    @Transactional
+    public void deletePost(Long postId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시물을 찾을 수 없습니다."));
+
+        post.verifyPostOwner(user);
+        postRepository.delete(post);
+    }
+
     private void updatePostByRequest(Post post, PostUpdateRequest request) {
         post.updateTitle(request.title());
         post.updateContent(request.content());

--- a/src/main/java/dev/backlog/domain/user/model/User.java
+++ b/src/main/java/dev/backlog/domain/user/model/User.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -71,6 +72,18 @@ public class User {
         this.introduction = introduction;
         this.blogTitle = blogTitle;
         this.deletedDate = LocalDate.MAX;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof User user)) return false;
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 
 }

--- a/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
+++ b/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
@@ -31,14 +31,13 @@ import java.util.Set;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
-import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -211,7 +210,6 @@ class PostControllerTest extends ControllerTestConfig {
 
         mockMvc.perform(put("/api/posts/{postId}", postId)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header("AuthrizationCode", "asdasd")
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNoContent())
                 .andDo(document("post-update",
@@ -229,6 +227,22 @@ class PostControllerTest extends ControllerTestConfig {
                                         fieldWithPath("path").type(JsonFieldType.STRING).description("게시물 경로"))
                         )
                 );
+    }
+
+    @DisplayName("게시물의 식별자를 입력받아 삭제후 204상태코드를 반환한다.")
+    @Test
+    void deletePostTest() throws Exception {
+        Long postId = 1L;
+        Long userId = 1L;
+
+        doNothing().when(postService).deletePost(postId, userId);
+
+        mockMvc.perform(delete("/api/posts/{postId}", postId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(document("post-delete",
+                        resourceDetails().tag("게시물").description("게시물 삭제"),
+                        pathParameters(parameterWithName("postId").description("게시물 식별자")))
+                ).andExpect(status().isNoContent());
     }
 
     private PostUpdateRequest getPostUpdateRequest() {

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -16,11 +16,12 @@ import dev.backlog.domain.post.dto.PostUpdateRequest;
 import dev.backlog.domain.post.infrastructure.persistence.PostHashtagRepository;
 import dev.backlog.domain.post.infrastructure.persistence.PostRepository;
 import dev.backlog.domain.post.model.Post;
+import dev.backlog.domain.post.model.PostHashtag;
 import dev.backlog.domain.series.infrastructure.persistence.SeriesRepository;
 import dev.backlog.domain.series.model.Series;
-import dev.backlog.domain.post.model.PostHashtag;
 import dev.backlog.domain.user.infrastructure.persistence.UserRepository;
 import dev.backlog.domain.user.model.User;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -234,6 +235,26 @@ class PostServiceTest extends TestContainerConfig {
                 () -> assertThat(변경된_게시물.getPath()).isEqualTo("변경된 경로"),
                 () -> assertThat(postHashtags.size()).isOne()
         );
+    }
+
+    @DisplayName("게시물 작성자는 게시물을 삭제할 수 있다.")
+    @Test
+    void deletePostTest() {
+        Long postId = 게시물1.getId();
+
+        postService.deletePost(postId, 유저1.getId());
+        boolean result = postRepository.findById(postId).isPresent();
+
+        assertThat(result).isFalse();
+    }
+
+    @DisplayName("게시물 작성자가 아니면 게시물을 삭제할 수 없다.")
+    @Test
+    void deletePostFailTest() {
+        Long postId = 게시물1.getId();
+
+        Assertions.assertThatThrownBy(() -> postService.deletePost(postId, 유저1.getId() + 1))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     private PostUpdateRequest getPostUpdateRequest() {


### PR DESCRIPTION
close: #54 
>
- 게시물 삭제
    - 게시물은 작성자만 삭제할 수 있다
    - 작성자가 아니라면 예외를 반환한다.

## 🍸 More
>
테스트코드 구현
