### PR TITLE
닉네임 + 해쉬태그를 통한 게시물 검색

### DIFF
--- a/src/main/java/dev/backlog/domain/post/api/PostController.java
+++ b/src/main/java/dev/backlog/domain/post/api/PostController.java
@@ -45,6 +45,17 @@ public class PostController {
         return ResponseEntity.ok(postResponse);
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<PostSliceResponse<PostSummaryResponse>> searchByNicknameAndHashtag(
+            @RequestParam(required = false) String nickname,
+            @RequestParam(required = false) String hashtag,
+            @PageableDefault(size = 30, sort = "createdAt", direction = DESC) Pageable pageable
+    ) {
+        PostSliceResponse<PostSummaryResponse> postSliceResponse = postService.searchByUserNickname(nickname, hashtag, pageable);
+
+        return ResponseEntity.ok(postSliceResponse);
+    }
+
     @GetMapping("/like")
     public ResponseEntity<PostSliceResponse<PostSummaryResponse>> findLikedPosts(Long userId,
                                                                                  @PageableDefault(size = 30, sort = "createdAt", direction = DESC) Pageable pageable) {
@@ -71,14 +82,6 @@ public class PostController {
                                                                                  Pageable pageable) {
         PostSliceResponse<PostSummaryResponse> trendPosts = postService.findLikedPosts(timePeriod, pageable);
         return ResponseEntity.ok(trendPosts);
-    }
-
-    @GetMapping("/{nickname}")
-    public ResponseEntity<PostSliceResponse<PostSummaryResponse>> searchByUserNickname(@PathVariable String nickname,
-                                                                                       @PageableDefault(size = 30, sort = "createdAt", direction = DESC) Pageable pageable) {
-        PostSliceResponse<PostSummaryResponse> postSliceResponse = postService.searchByUserNickname(nickname, pageable);
-
-        return ResponseEntity.ok().body(postSliceResponse);
     }
 
     @PutMapping("/{postId}")

--- a/src/main/java/dev/backlog/domain/post/api/PostController.java
+++ b/src/main/java/dev/backlog/domain/post/api/PostController.java
@@ -66,11 +66,19 @@ public class PostController {
         return ResponseEntity.ok(recentPosts);
     }
 
-    @GetMapping("trend")
+    @GetMapping("/trend")
     public ResponseEntity<PostSliceResponse<PostSummaryResponse>> findTrendPosts(@RequestParam(defaultValue = "week") String timePeriod,
                                                                                  Pageable pageable) {
         PostSliceResponse<PostSummaryResponse> trendPosts = postService.findLikedPosts(timePeriod, pageable);
         return ResponseEntity.ok(trendPosts);
+    }
+
+    @GetMapping("/{nickname}")
+    public ResponseEntity<PostSliceResponse<PostSummaryResponse>> searchByUserNickname(@PathVariable String nickname,
+                                                                                       @PageableDefault(size = 30, sort = "createdAt", direction = DESC) Pageable pageable) {
+        PostSliceResponse<PostSummaryResponse> postSliceResponse = postService.searchByUserNickname(nickname, pageable);
+
+        return ResponseEntity.ok().body(postSliceResponse);
     }
 
     @PutMapping("/{postId}")

--- a/src/main/java/dev/backlog/domain/post/infrastructure/persistence/PostQueryRepository.java
+++ b/src/main/java/dev/backlog/domain/post/infrastructure/persistence/PostQueryRepository.java
@@ -8,4 +8,6 @@ public interface PostQueryRepository {
 
     Slice<Post> findLikedPostsByTimePeriod(String timePeriod, Pageable pageable);
 
+    Slice<Post> findByUserNicknameAndHashtag(String nickName, String hashtag, Pageable pageable);
+
 }

--- a/src/main/java/dev/backlog/domain/post/infrastructure/persistence/PostRepository.java
+++ b/src/main/java/dev/backlog/domain/post/infrastructure/persistence/PostRepository.java
@@ -20,6 +20,4 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostQueryRepo
 
     Slice<Post> findAllByUserAndSeries(User user, Series series, Pageable pageable);
 
-    Slice<Post> findByUserNickname(String nickName, Pageable pageable);
-
 }

--- a/src/main/java/dev/backlog/domain/post/infrastructure/persistence/PostRepository.java
+++ b/src/main/java/dev/backlog/domain/post/infrastructure/persistence/PostRepository.java
@@ -20,4 +20,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostQueryRepo
 
     Slice<Post> findAllByUserAndSeries(User user, Series series, Pageable pageable);
 
+    Slice<Post> findByUserNickname(String nickName, Pageable pageable);
+
 }

--- a/src/main/java/dev/backlog/domain/post/infrastructure/persistence/PostRepository.java
+++ b/src/main/java/dev/backlog/domain/post/infrastructure/persistence/PostRepository.java
@@ -11,10 +11,10 @@ import org.springframework.data.jpa.repository.Query;
 public interface PostRepository extends JpaRepository<Post, Long>, PostQueryRepository {
 
     @Query(""" 
-            SELECT p 
-            FROM Post p 
-            INNER JOIN Like l ON l.post.id = p.id 
-            WHERE p.isPublic = true AND l.user.id = :userId 
+            SELECT p
+            FROM Post p
+            INNER JOIN Like l ON l.post.id = p.id
+            WHERE p.isPublic = true AND l.user.id = :userId
             """)
     Slice<Post> findLikedPostsByUserId(Long userId, Pageable pageable);
 

--- a/src/main/java/dev/backlog/domain/post/service/PostService.java
+++ b/src/main/java/dev/backlog/domain/post/service/PostService.java
@@ -72,8 +72,8 @@ public class PostService {
         return savedPost.getId();
     }
 
-    public PostSliceResponse<PostSummaryResponse> searchByUserNickname(String nickname, Pageable pageable) {
-        Slice<PostSummaryResponse> postSummaryResponses = fetchPostsByUserNickname(nickname, pageable);
+    public PostSliceResponse<PostSummaryResponse> searchByUserNickname(String nickname, String hashtag, Pageable pageable) {
+        Slice<PostSummaryResponse> postSummaryResponses = fetchPostsByUserNickname(nickname, hashtag, pageable);
         return PostSliceResponse.from(postSummaryResponses);
     }
 
@@ -136,8 +136,8 @@ public class PostService {
         postRepository.delete(post);
     }
 
-    private Slice<PostSummaryResponse> fetchPostsByUserNickname(String nickname, Pageable pageable) {
-        return postRepository.findByUserNickname(nickname, pageable)
+    private Slice<PostSummaryResponse> fetchPostsByUserNickname(String nickname, String hashtag, Pageable pageable) {
+        return postRepository.findByUserNicknameAndHashtag(nickname, hashtag, pageable)
                 .map(this::createPostSummaryResponse);
     }
 

--- a/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
+++ b/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
@@ -40,6 +40,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PostController.class)
@@ -311,6 +312,26 @@ class PostControllerTest extends ControllerTestConfig {
                                         fieldWithPath("path").type(JsonFieldType.STRING).description("게시물 경로"))
                         )
                 );
+    }
+
+    @DisplayName("사용자 닉네임으로 게시물리스트를 조회후 상태코드 200과 함께 데이터를 리턴한다.")
+    @Test
+    void searchByUserNicknameTest() throws Exception {
+        // Arrange
+        String nickname = "testUser";
+        final long postId = 1l;
+        final long userId = 1l;
+        PostSliceResponse<PostSummaryResponse> postSliceResponse = getPostSliceResponse(postId, userId);
+
+        when(postService.searchByUserNickname(any(), any(), any())).thenReturn(postSliceResponse);
+
+        mockMvc.perform(get("/api/posts/search")
+                        .param("hashtag", "tag")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.numberOfElements").value(postSliceResponse.numberOfElements()))
+                .andExpect(jsonPath("$.hasNext").value(false))
+                .andReturn();
     }
 
     private PostUpdateRequest getPostUpdateRequest() {

--- a/src/test/java/dev/backlog/domain/post/infrastructure/persistence/PostQueryRepositoryImplTest.java
+++ b/src/test/java/dev/backlog/domain/post/infrastructure/persistence/PostQueryRepositoryImplTest.java
@@ -1,23 +1,32 @@
 package dev.backlog.domain.post.infrastructure.persistence;
 
 import dev.backlog.common.RepositoryTest;
+import dev.backlog.domain.hashtag.infrastructure.persistence.HashtagRepository;
+import dev.backlog.domain.hashtag.model.Hashtag;
 import dev.backlog.domain.like.infrastructure.persistence.LikeRepository;
 import dev.backlog.domain.like.model.Like;
 import dev.backlog.domain.post.model.Post;
+import dev.backlog.domain.post.model.PostHashtag;
 import dev.backlog.domain.user.infrastructure.persistence.UserRepository;
 import dev.backlog.domain.user.model.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static dev.backlog.common.fixture.EntityFixture.게시물1;
+import static dev.backlog.common.fixture.EntityFixture.게시물_모음;
 import static dev.backlog.common.fixture.EntityFixture.유저1;
 import static dev.backlog.common.fixture.EntityFixture.좋아요1;
+import static dev.backlog.common.fixture.EntityFixture.해쉬태그_모음;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -31,6 +40,23 @@ class PostQueryRepositoryImplTest extends RepositoryTest {
 
     @Autowired
     LikeRepository likeRepository;
+
+    @Autowired
+    HashtagRepository hashtagRepository;
+
+    @Autowired
+    PostHashtagRepository postHashtagRepository;
+
+    private User 유저1;
+    private List<Post> 게시물_모음;
+    private Hashtag 해쉬태그;
+
+    @BeforeEach
+    void setUp() {
+        유저1 = 유저1();
+        게시물_모음 = 게시물_모음(유저1, null);
+        해쉬태그 = 해쉬태그_모음().get(0);
+    }
 
     @DisplayName("오늘, 이번 주, 이번 달, 올해 필터링을 통해 좋아요 많이 받은 순서로 게시물을 조회할 수 있다.")
     @ParameterizedTest
@@ -62,6 +88,61 @@ class PostQueryRepositoryImplTest extends RepositoryTest {
                 () -> assertThat(postSlice.getContent().get(0)).isEqualTo(post1),
                 () -> assertThat(postSlice.getContent().get(1)).isEqualTo(post2)
         );
+    }
+
+
+    @DisplayName("닉네임을 통해 게시물을 조회할 수 있다.")
+    @Test
+    void findByNicknameTest() {
+        User user = userRepository.save(유저1);
+        postRepository.saveAll(게시물_모음(user, null));
+
+        int pageSize = 20;
+        PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.Direction.ASC, "createdAt");
+        Slice<Post> posts = postRepository.findByUserNicknameAndHashtag(user.getNickname(), null, pageRequest);
+
+        assertThat(posts.getSize()).isEqualTo(pageSize);
+        assertThat(posts.hasNext()).isTrue();
+    }
+
+    @DisplayName("해쉬태그를 통해 게시물을 조회할 수 있다.")
+    @Test
+    void findByHashtagTest() {
+        User user = userRepository.save(유저1);
+        Hashtag hashtag = hashtagRepository.save(해쉬태그);
+        List<Post> savedPosts = postRepository.saveAll(게시물_모음(user, null));
+        List<PostHashtag> postHashtags = createPostHashtags(hashtag, savedPosts);
+
+        int pageSize = 20;
+        PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.Direction.ASC, "createdAt");
+        Slice<Post> posts = postRepository.findByUserNicknameAndHashtag(null, "해쉬태그", pageRequest);
+
+        assertThat(posts.getNumberOfElements()).isEqualTo(postHashtags.size());
+        assertThat(posts.hasNext()).isFalse();
+    }
+
+    @DisplayName("닉네임과 해쉬태그를 통해 게시물을 조회할 수 있다.")
+    @Test
+    void findByNicknameAndHashtagTest() {
+        User user = userRepository.save(유저1);
+        Hashtag hashtag = hashtagRepository.save(해쉬태그);
+        List<Post> savedPosts = postRepository.saveAll(게시물_모음(user, null));
+        List<PostHashtag> postHashtags = createPostHashtags(hashtag, savedPosts);
+
+        int pageSize = 20;
+        PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.Direction.ASC, "createdAt");
+        Slice<Post> posts = postRepository.findByUserNicknameAndHashtag(user.getNickname(), "해쉬태그", pageRequest);
+
+        assertThat(posts.getNumberOfElements()).isEqualTo(postHashtags.size());
+        assertThat(posts.hasNext()).isFalse();
+    }
+
+    private List<PostHashtag> createPostHashtags(Hashtag hashtag, List<Post> posts) {
+        List<PostHashtag> postHashtags = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            postHashtags.add(new PostHashtag(hashtag, posts.get(i)));
+        }
+        return postHashtagRepository.saveAll(postHashtags);
     }
 
 }

--- a/src/test/java/dev/backlog/domain/post/infrastructure/persistence/PostRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/post/infrastructure/persistence/PostRepositoryTest.java
@@ -101,19 +101,4 @@ class PostRepositoryTest extends RepositoryTest {
         );
     }
 
-    @DisplayName("닉네임을 통해 게시물을 조회할 수 있다.")
-    @Test
-    void findByNicknameTest() {
-        User user = userRepository.save(유저1);
-        Series series = seriesRepository.save(시리즈1(user));
-        postRepository.saveAll(게시물_모음(user, series));
-
-        int pageSize = 20;
-        PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.Direction.ASC, "createdAt");
-        Slice<Post> posts = postRepository.findByUserNickname(user.getNickname(), pageRequest);
-
-        assertThat(posts.getSize()).isEqualTo(pageSize);
-        assertThat(posts.hasNext()).isTrue();
-    }
-
 }

--- a/src/test/java/dev/backlog/domain/post/infrastructure/persistence/PostRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/post/infrastructure/persistence/PostRepositoryTest.java
@@ -101,4 +101,19 @@ class PostRepositoryTest extends RepositoryTest {
         );
     }
 
+    @DisplayName("닉네임을 통해 게시물을 조회할 수 있다.")
+    @Test
+    void findByNicknameTest() {
+        User user = userRepository.save(유저1);
+        Series series = seriesRepository.save(시리즈1(user));
+        postRepository.saveAll(게시물_모음(user, series));
+
+        int pageSize = 20;
+        PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.Direction.ASC, "createdAt");
+        Slice<Post> posts = postRepository.findByUserNickname(user.getNickname(), pageRequest);
+
+        assertThat(posts.getSize()).isEqualTo(pageSize);
+        assertThat(posts.hasNext()).isTrue();
+    }
+
 }

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -294,6 +294,21 @@ class PostServiceTest extends TestContainerConfig {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @DisplayName("사용자 닉네임으로 게시물리스트를 조회해 요약 리스트로 반환한다.")
+    @Test
+    void searchByUserNicknameTest() {
+        User user = userRepository.save(유저1);
+        postRepository.saveAll(게시물_모음);
+
+        int pageSize = 20;
+        PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.Direction.ASC, "createdAt");
+        PostSliceResponse<PostSummaryResponse> postSliceResponse = postService.searchByUserNickname(user.getNickname(), pageRequest);
+
+        assertThat(postSliceResponse.numberOfElements()).isEqualTo(pageSize);
+        assertThat(postSliceResponse.hasNext()).isTrue();
+
+    }
+
     private PostUpdateRequest getPostUpdateRequest() {
         return new PostUpdateRequest(
                 null,

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -166,7 +166,7 @@ class PostServiceTest extends TestContainerConfig {
         PageRequest pageRequest = PageRequest.of(1, 20, Sort.Direction.DESC, "createdAt");
 
         //when
-        PostSliceResponse postSliceResponse = postService.findLikedPostsByUser(user.getId(), pageRequest);
+        PostSliceResponse<PostSummaryResponse> postSliceResponse = postService.findLikedPostsByUser(user.getId(), pageRequest);
 
         //then
         assertAll(

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -302,7 +302,7 @@ class PostServiceTest extends TestContainerConfig {
 
         int pageSize = 20;
         PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.Direction.ASC, "createdAt");
-        PostSliceResponse<PostSummaryResponse> postSliceResponse = postService.searchByUserNickname(user.getNickname(), pageRequest);
+        PostSliceResponse<PostSummaryResponse> postSliceResponse = postService.searchByUserNickname(user.getNickname(), "", pageRequest);
 
         assertThat(postSliceResponse.numberOfElements()).isEqualTo(pageSize);
         assertThat(postSliceResponse.hasNext()).isTrue();


### PR DESCRIPTION
close: #64 
## 📄 Summary
>
-  사용자 닉네임을 통한 게시물 검색
-  해쉬태그를 통한 게시물 검색
- 닉네임 + 해쉬태그를 통한 게시물 검색
- 테스트코드

## 🍸 More
>
