### PR TITLE
Post 도메인을 페어프로그래밍으로 리팩터링

### DIFF
--- a/src/main/java/dev/backlog/common/UserArgumentResolver.java
+++ b/src/main/java/dev/backlog/common/UserArgumentResolver.java
@@ -1,7 +1,7 @@
 package dev.backlog.common;
 
 import dev.backlog.domain.auth.model.oauth.JwtTokenProvider;
-import dev.backlog.domain.user.dto.UserPrincipal;
+import dev.backlog.domain.user.dto.AuthInfo;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -19,12 +19,12 @@ public class UserArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.getParameterType().equals(UserPrincipal.class);
+        return parameter.getParameterType().equals(AuthInfo.class);
     }
 
     @Override
-    public UserPrincipal resolveArgument(MethodParameter parampeter, ModelAndViewContainer mavContainer,
-                                         NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+    public AuthInfo resolveArgument(MethodParameter parampeter, ModelAndViewContainer mavContainer,
+                                    NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest httpServletRequest = (HttpServletRequest) webRequest.getNativeRequest();
         String authHeader = httpServletRequest.getHeader("Authorization");
 
@@ -32,7 +32,7 @@ public class UserArgumentResolver implements HandlerMethodArgumentResolver {
             String token = authHeader.substring(7);
             Long userId = jwtTokenProvider.extractUserId(token);
 
-            return new UserPrincipal(userId);
+            return new AuthInfo(userId);
         }
         throw new IllegalArgumentException("잘못된 권한 헤더입니다.");
     }

--- a/src/main/java/dev/backlog/domain/post/api/PostController.java
+++ b/src/main/java/dev/backlog/domain/post/api/PostController.java
@@ -7,6 +7,7 @@ import dev.backlog.domain.post.dto.PostSliceResponse;
 import dev.backlog.domain.post.dto.PostSummaryResponse;
 import dev.backlog.domain.post.dto.PostUpdateRequest;
 import dev.backlog.domain.post.service.PostService;
+import dev.backlog.domain.user.dto.AuthInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -32,11 +33,41 @@ public class PostController {
 
     private final PostService postService;
 
+    // TODO: 2023/09/06 userId에서 nickname으로 변경
+
     @PostMapping
-    public ResponseEntity<Void> create(@RequestBody PostCreateRequest request, Long userId) {
-        Long postId = postService.create(request, userId);
+    public ResponseEntity<Void> create(@RequestBody PostCreateRequest request, AuthInfo authInfo) {
+        Long postId = postService.create(request, authInfo);
 
         return ResponseEntity.created(URI.create("/posts/" + postId)).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<PostSliceResponse<PostSummaryResponse>> findSeriesPosts(String series,
+                                                                                  Long userId,
+                                                                                  @PageableDefault(size = 30, sort = "createdAt") Pageable pageable) {
+        PostSliceResponse<PostSummaryResponse> seriesPosts = postService.findPostsByUserAndSeries(userId, series, pageable);
+        return ResponseEntity.ok(seriesPosts);
+    }
+
+    @GetMapping("/like")
+    public ResponseEntity<PostSliceResponse<PostSummaryResponse>> findLikedPosts(Long userId,
+                                                                                 @PageableDefault(size = 30, sort = "createdAt", direction = DESC) Pageable pageable) {
+        PostSliceResponse<PostSummaryResponse> likedPosts = postService.findLikedPostsByUser(userId, pageable);
+        return ResponseEntity.ok(likedPosts);
+    }
+
+    @GetMapping("/recent")
+    public ResponseEntity<PostSliceResponse<PostSummaryResponse>> findRecentPosts(@PageableDefault(size = 30, sort = "createdAt", direction = DESC) Pageable pageable) {
+        PostSliceResponse<PostSummaryResponse> recentPosts = postService.findPostsInLatestOrder(pageable);
+        return ResponseEntity.ok(recentPosts);
+    }
+
+    @GetMapping("/trend")
+    public ResponseEntity<PostSliceResponse<PostSummaryResponse>> findTrendPosts(@RequestParam(defaultValue = "week") String timePeriod,
+                                                                                 Pageable pageable) {
+        PostSliceResponse<PostSummaryResponse> trendPosts = postService.findLikedPosts(timePeriod, pageable);
+        return ResponseEntity.ok(trendPosts);
     }
 
     @GetMapping("/{postId}")
@@ -52,36 +83,7 @@ public class PostController {
             @PageableDefault(size = 30, sort = "createdAt", direction = DESC) Pageable pageable
     ) {
         PostSliceResponse<PostSummaryResponse> postSliceResponse = postService.searchByUserNickname(nickname, hashtag, pageable);
-
         return ResponseEntity.ok(postSliceResponse);
-    }
-
-    @GetMapping("/like")
-    public ResponseEntity<PostSliceResponse<PostSummaryResponse>> findLikedPosts(Long userId,
-                                                                                 @PageableDefault(size = 30, sort = "createdAt", direction = DESC) Pageable pageable) {
-        PostSliceResponse<PostSummaryResponse> likedPosts = postService.findLikedPostsByUser(userId, pageable);
-        return ResponseEntity.ok(likedPosts);
-    }
-
-    @GetMapping
-    public ResponseEntity<PostSliceResponse<PostSummaryResponse>> findSeriesPosts(String series,
-                                                                                  Long userId,
-                                                                                  @PageableDefault(size = 30, sort = "createdAt") Pageable pageable) {
-        PostSliceResponse<PostSummaryResponse> seriesPosts = postService.findPostsByUserAndSeries(userId, series, pageable);
-        return ResponseEntity.ok(seriesPosts);
-    }
-
-    @GetMapping("/recent")
-    public ResponseEntity<PostSliceResponse<PostSummaryResponse>> findRecentPosts(@PageableDefault(size = 30, sort = "createdAt", direction = DESC) Pageable pageable) {
-        PostSliceResponse<PostSummaryResponse> recentPosts = postService.findPostsInLatestOrder(pageable);
-        return ResponseEntity.ok(recentPosts);
-    }
-
-    @GetMapping("/trend")
-    public ResponseEntity<PostSliceResponse<PostSummaryResponse>> findTrendPosts(@RequestParam(defaultValue = "week") String timePeriod,
-                                                                                 Pageable pageable) {
-        PostSliceResponse<PostSummaryResponse> trendPosts = postService.findLikedPosts(timePeriod, pageable);
-        return ResponseEntity.ok(trendPosts);
     }
 
     @PutMapping("/{postId}")

--- a/src/main/java/dev/backlog/domain/post/api/PostController.java
+++ b/src/main/java/dev/backlog/domain/post/api/PostController.java
@@ -38,7 +38,6 @@ public class PostController {
     @PostMapping
     public ResponseEntity<Void> create(@RequestBody PostCreateRequest request, AuthInfo authInfo) {
         Long postId = postService.create(request, authInfo);
-
         return ResponseEntity.created(URI.create("/posts/" + postId)).build();
     }
 

--- a/src/main/java/dev/backlog/domain/post/infra/PostRepositoryAdapter.java
+++ b/src/main/java/dev/backlog/domain/post/infra/PostRepositoryAdapter.java
@@ -1,0 +1,58 @@
+package dev.backlog.domain.post.infra;
+
+import dev.backlog.domain.post.infra.jpa.PostJpaRepository;
+import dev.backlog.domain.post.model.Post;
+import dev.backlog.domain.post.model.repository.PostRepository;
+import dev.backlog.domain.series.model.Series;
+import dev.backlog.domain.user.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepositoryAdapter implements PostRepository {
+
+    private final PostJpaRepository postJpaRepository;
+
+    @Override
+    public Post save(Post post) {
+        return postJpaRepository.save(post);
+    }
+
+    @Override
+    public List<Post> saveAll(Iterable<Post> posts) {
+        return postJpaRepository.saveAll(posts);
+    }
+
+    @Override
+    public Slice<Post> findAll(Pageable pageable) {
+        return postJpaRepository.findAll(pageable);
+    }
+
+    @Override
+    public Post getById(Long postId) {
+        return postJpaRepository.findById(postId)
+                .orElseThrow(() -> new NoSuchElementException("유저를 찾을 수 없습니다."));
+    }
+
+    @Override
+    public void delete(Post post) {
+        postJpaRepository.delete(post);
+    }
+
+    @Override
+    public Slice<Post> findLikedPostsByUserId(Long userId, Pageable pageable) {
+        return postJpaRepository.findLikedPostsByUserId(userId, pageable);
+    }
+
+    @Override
+    public Slice<Post> findAllByUserAndSeries(User user, Series series, Pageable pageable) {
+        return postJpaRepository.findAllByUserAndSeries(user, series, pageable);
+    }
+
+}

--- a/src/main/java/dev/backlog/domain/post/infra/jpa/PostHashtagRepository.java
+++ b/src/main/java/dev/backlog/domain/post/infra/jpa/PostHashtagRepository.java
@@ -1,4 +1,4 @@
-package dev.backlog.domain.post.infrastructure.persistence;
+package dev.backlog.domain.post.infra.jpa;
 
 import dev.backlog.domain.hashtag.model.Hashtag;
 import dev.backlog.domain.post.model.Post;

--- a/src/main/java/dev/backlog/domain/post/infra/jpa/PostJpaRepository.java
+++ b/src/main/java/dev/backlog/domain/post/infra/jpa/PostJpaRepository.java
@@ -1,4 +1,4 @@
-package dev.backlog.domain.post.infrastructure.persistence;
+package dev.backlog.domain.post.infra.jpa;
 
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.series.model.Series;
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface PostRepository extends JpaRepository<Post, Long>, PostQueryRepository {
+public interface PostJpaRepository extends JpaRepository<Post, Long> {
 
     @Query(""" 
             SELECT p

--- a/src/main/java/dev/backlog/domain/post/infra/jpa/query/PostQueryDslRepositoryImpl.java
+++ b/src/main/java/dev/backlog/domain/post/infra/jpa/query/PostQueryDslRepositoryImpl.java
@@ -40,7 +40,7 @@ public class PostQueryDslRepositoryImpl implements PostQueryRepository {
                 .where(getDateCondition(timePeriod))
                 .orderBy(post.likes.size().desc())
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1l)
+                .limit(pageable.getPageSize() + 1L)
                 .fetch();
 
         List<Post> content = getContent(postList);

--- a/src/main/java/dev/backlog/domain/post/infra/jpa/query/PostQueryDslRepositoryImpl.java
+++ b/src/main/java/dev/backlog/domain/post/infra/jpa/query/PostQueryDslRepositoryImpl.java
@@ -1,4 +1,4 @@
-package dev.backlog.domain.post.infrastructure.persistence;
+package dev.backlog.domain.post.infra.jpa.query;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -7,11 +7,13 @@ import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import dev.backlog.domain.hashtag.model.QHashtag;
 import dev.backlog.domain.post.model.Post;
+import dev.backlog.domain.post.model.repository.PostQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
@@ -24,9 +26,10 @@ import static dev.backlog.domain.post.model.QPost.post;
 import static dev.backlog.domain.post.model.QPostHashtag.postHashtag;
 import static dev.backlog.domain.user.model.QUser.user;
 
-@Transactional(readOnly = true)
+@Repository
 @RequiredArgsConstructor
-public class PostQueryRepositoryImpl implements PostQueryRepository {
+@Transactional(readOnly = true)
+public class PostQueryDslRepositoryImpl implements PostQueryRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 

--- a/src/main/java/dev/backlog/domain/post/model/repository/PostQueryRepository.java
+++ b/src/main/java/dev/backlog/domain/post/model/repository/PostQueryRepository.java
@@ -1,4 +1,4 @@
-package dev.backlog.domain.post.infrastructure.persistence;
+package dev.backlog.domain.post.model.repository;
 
 import dev.backlog.domain.post.model.Post;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/dev/backlog/domain/post/model/repository/PostRepository.java
+++ b/src/main/java/dev/backlog/domain/post/model/repository/PostRepository.java
@@ -1,0 +1,27 @@
+package dev.backlog.domain.post.model.repository;
+
+import dev.backlog.domain.post.model.Post;
+import dev.backlog.domain.series.model.Series;
+import dev.backlog.domain.user.model.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public interface PostRepository {
+
+    Post save(Post post);
+
+    List<Post> saveAll(Iterable<Post> posts);
+
+    Slice<Post> findAll(Pageable pageable);
+
+    Post getById(Long postId);
+
+    void delete(Post post);
+
+    Slice<Post> findLikedPostsByUserId(Long userId, Pageable pageable);
+
+    Slice<Post> findAllByUserAndSeries(User user, Series series, Pageable pageable);
+
+}

--- a/src/main/java/dev/backlog/domain/post/service/PostHashtagService.java
+++ b/src/main/java/dev/backlog/domain/post/service/PostHashtagService.java
@@ -2,7 +2,7 @@ package dev.backlog.domain.post.service;
 
 import dev.backlog.domain.hashtag.infrastructure.persistence.HashtagRepository;
 import dev.backlog.domain.hashtag.model.Hashtag;
-import dev.backlog.domain.post.infrastructure.persistence.PostHashtagRepository;
+import dev.backlog.domain.post.infra.jpa.PostHashtagRepository;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.PostHashtag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/dev/backlog/domain/post/service/PostService.java
+++ b/src/main/java/dev/backlog/domain/post/service/PostService.java
@@ -12,6 +12,7 @@ import dev.backlog.domain.post.infrastructure.persistence.PostRepository;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.series.infrastructure.persistence.SeriesRepository;
 import dev.backlog.domain.series.model.Series;
+import dev.backlog.domain.user.dto.AuthInfo;
 import dev.backlog.domain.user.infrastructure.persistence.UserRepository;
 import dev.backlog.domain.user.model.User;
 import lombok.RequiredArgsConstructor;
@@ -58,8 +59,8 @@ public class PostService {
     }
 
     @Transactional
-    public Long create(PostCreateRequest request, Long userId) {
-        User user = userRepository.findById(userId)
+    public Long create(PostCreateRequest request, AuthInfo authInfo) {
+        User user = userRepository.findById(authInfo.userId())
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
         Series series = seriesRepository.findByUserAndName(user, request.series())
                 .orElse(null);

--- a/src/main/java/dev/backlog/domain/user/api/UserController.java
+++ b/src/main/java/dev/backlog/domain/user/api/UserController.java
@@ -1,7 +1,7 @@
 package dev.backlog.domain.user.api;
 
+import dev.backlog.domain.user.dto.AuthInfo;
 import dev.backlog.domain.user.dto.UserDetailsResponse;
-import dev.backlog.domain.user.dto.UserPrincipal;
 import dev.backlog.domain.user.dto.UserResponse;
 import dev.backlog.domain.user.dto.UserUpdateRequest;
 import dev.backlog.domain.user.service.UserService;
@@ -27,8 +27,8 @@ public class UserController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<UserDetailsResponse> findMyProfile(UserPrincipal userPrincipal) {
-        return ResponseEntity.ok(userService.findMyProfile(userPrincipal.userId()));
+    public ResponseEntity<UserDetailsResponse> findMyProfile(AuthInfo authInfo) {
+        return ResponseEntity.ok(userService.findMyProfile(authInfo.userId()));
     }
 
     @PutMapping("/me")

--- a/src/main/java/dev/backlog/domain/user/dto/AuthInfo.java
+++ b/src/main/java/dev/backlog/domain/user/dto/AuthInfo.java
@@ -1,0 +1,4 @@
+package dev.backlog.domain.user.dto;
+
+public record AuthInfo(Long userId) {
+}

--- a/src/main/java/dev/backlog/domain/user/dto/UserPrincipal.java
+++ b/src/main/java/dev/backlog/domain/user/dto/UserPrincipal.java
@@ -1,4 +1,0 @@
-package dev.backlog.domain.user.dto;
-
-public record UserPrincipal(Long userId) {
-}

--- a/src/test/java/dev/backlog/common/RepositoryTest.java
+++ b/src/test/java/dev/backlog/common/RepositoryTest.java
@@ -1,11 +1,35 @@
 package dev.backlog.common;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import dev.backlog.common.config.JpaConfig;
 import dev.backlog.common.config.QueryDslConfig;
+import dev.backlog.domain.post.infra.PostRepositoryAdapter;
+import dev.backlog.domain.post.infra.jpa.PostJpaRepository;
+import dev.backlog.domain.post.infra.jpa.query.PostQueryDslRepositoryImpl;
+import dev.backlog.domain.post.model.repository.PostQueryRepository;
+import dev.backlog.domain.post.model.repository.PostRepository;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
-@Import(value = {QueryDslConfig.class, JpaConfig.class})
+@Import(value = {QueryDslConfig.class, JpaConfig.class, RepositoryTest.QueryDslTestConfig.class})
 public class RepositoryTest {
+
+    @TestConfiguration
+    public static class QueryDslTestConfig {
+
+        @Bean
+        public PostRepository postRepository(PostJpaRepository postJpaRepository) {
+            return new PostRepositoryAdapter(postJpaRepository);
+        }
+
+        @Bean
+        public PostQueryRepository postQueryRepository(JPAQueryFactory jpaQueryFactory) {
+            return new PostQueryDslRepositoryImpl(jpaQueryFactory);
+        }
+
+    }
+
 }

--- a/src/test/java/dev/backlog/common/config/ControllerTestConfig.java
+++ b/src/test/java/dev/backlog/common/config/ControllerTestConfig.java
@@ -22,6 +22,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 @ExtendWith({RestDocumentationExtension.class})
 public abstract class ControllerTestConfig {
 
+    protected final String jwtToken = "Bearer aaaaaaaa.bbbbbbb.ccccccc";
+
     protected ObjectMapper objectMapper = new ObjectMapper();
 
     protected MockMvc mockMvc;

--- a/src/test/java/dev/backlog/domain/comment/infrastructure/persistence/CommentRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/comment/infrastructure/persistence/CommentRepositoryTest.java
@@ -2,7 +2,7 @@ package dev.backlog.domain.comment.infrastructure.persistence;
 
 import dev.backlog.common.RepositoryTest;
 import dev.backlog.domain.comment.model.Comment;
-import dev.backlog.domain.post.infrastructure.persistence.PostRepository;
+import dev.backlog.domain.post.infra.jpa.PostJpaRepository;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.user.infrastructure.persistence.UserRepository;
 import dev.backlog.domain.user.model.User;
@@ -23,7 +23,7 @@ class CommentRepositoryTest extends RepositoryTest {
     private CommentRepository commentRepository;
 
     @Autowired
-    private PostRepository postRepository;
+    private PostJpaRepository postRepository;
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/dev/backlog/domain/like/infrastructure/persistence/LikeRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/like/infrastructure/persistence/LikeRepositoryTest.java
@@ -1,7 +1,7 @@
 package dev.backlog.domain.like.infrastructure.persistence;
 
 import dev.backlog.common.RepositoryTest;
-import dev.backlog.domain.post.infrastructure.persistence.PostRepository;
+import dev.backlog.domain.post.infra.jpa.PostJpaRepository;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.user.infrastructure.persistence.UserRepository;
 import dev.backlog.domain.user.model.User;
@@ -23,7 +23,7 @@ class LikeRepositoryTest extends RepositoryTest {
     private UserRepository userRepository;
 
     @Autowired
-    private PostRepository postRepository;
+    private PostJpaRepository postRepository;
 
     @DisplayName("특정 게시물에 달린 좋아요 수를 조회할 수 있다.")
     @Test

--- a/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
+++ b/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
@@ -27,7 +27,6 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resour
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -51,7 +50,7 @@ class PostControllerTest extends ControllerTestConfig {
 
     @DisplayName("게시물 생성 요청을 받아 처리 후 201 코드를 반환하고 게시물 조회 URI를 반환한다.")
     @Test
-    void testCreate() throws Exception {
+    void createTest() throws Exception {
         Long userId = 1L;
         Long postId = 2L;
         PostCreateRequest request = new PostCreateRequest(
@@ -63,12 +62,13 @@ class PostControllerTest extends ControllerTestConfig {
                 "썸네일",
                 "경로"
         );
-        when(postService.create(any(PostCreateRequest.class), eq(userId)))
+        when(jwtTokenProvider.extractUserId(jwtToken)).thenReturn(userId);
+        when(postService.create(any(PostCreateRequest.class), any()))
                 .thenReturn(postId);
 
         mockMvc.perform(post("/api/posts")
-                        .param("userId", userId.toString())
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", jwtToken)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/posts/" + postId));

--- a/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
+++ b/src/test/java/dev/backlog/domain/post/api/PostControllerTest.java
@@ -372,7 +372,7 @@ class PostControllerTest extends ControllerTestConfig {
     }
 
     private PostSliceResponse<PostSummaryResponse> getPostSliceResponse(long postId, long userId) {
-        return new PostSliceResponse<PostSummaryResponse>(
+        return new PostSliceResponse<>(
                 10,
                 false,
                 List.of(new PostSummaryResponse(

--- a/src/test/java/dev/backlog/domain/post/infra/jpa/PostHashtagRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/post/infra/jpa/PostHashtagRepositoryTest.java
@@ -1,4 +1,4 @@
-package dev.backlog.domain.post.infrastructure.persistence;
+package dev.backlog.domain.post.infra.jpa;
 
 import dev.backlog.common.RepositoryTest;
 import dev.backlog.domain.hashtag.infrastructure.persistence.HashtagRepository;
@@ -28,7 +28,7 @@ class PostHashtagRepositoryTest extends RepositoryTest {
     private UserRepository userRepository;
 
     @Autowired
-    private PostRepository postRepository;
+    private PostJpaRepository postRepository;
 
     @Autowired
     private HashtagRepository hashtagRepository;

--- a/src/test/java/dev/backlog/domain/post/infra/jpa/PostQueryDslRepositoryImplTest.java
+++ b/src/test/java/dev/backlog/domain/post/infra/jpa/PostQueryDslRepositoryImplTest.java
@@ -1,12 +1,14 @@
-package dev.backlog.domain.post.infrastructure.persistence;
+package dev.backlog.domain.post.infra.jpa;
 
 import dev.backlog.common.RepositoryTest;
 import dev.backlog.domain.hashtag.infrastructure.persistence.HashtagRepository;
 import dev.backlog.domain.hashtag.model.Hashtag;
 import dev.backlog.domain.like.infrastructure.persistence.LikeRepository;
 import dev.backlog.domain.like.model.Like;
+import dev.backlog.domain.post.infra.PostRepositoryAdapter;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.PostHashtag;
+import dev.backlog.domain.post.model.repository.PostQueryRepository;
 import dev.backlog.domain.user.infrastructure.persistence.UserRepository;
 import dev.backlog.domain.user.model.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,10 +32,13 @@ import static dev.backlog.common.fixture.EntityFixture.해쉬태그_모음;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-class PostQueryRepositoryImplTest extends RepositoryTest {
+class PostQueryDslRepositoryImplTest extends RepositoryTest {
 
     @Autowired
-    PostRepository postRepository;
+    PostRepositoryAdapter postRepository;
+
+    @Autowired
+    PostQueryRepository postQueryRepository;
 
     @Autowired
     UserRepository userRepository;
@@ -56,6 +61,9 @@ class PostQueryRepositoryImplTest extends RepositoryTest {
         유저1 = 유저1();
         게시물_모음 = 게시물_모음(유저1, null);
         해쉬태그 = 해쉬태그_모음().get(0);
+
+        System.out.println("====================" + postRepository);
+        System.out.println("====================" + postRepository);
     }
 
     @DisplayName("오늘, 이번 주, 이번 달, 올해 필터링을 통해 좋아요 많이 받은 순서로 게시물을 조회할 수 있다.")
@@ -79,7 +87,7 @@ class PostQueryRepositoryImplTest extends RepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 30);
 
         //when
-        Slice<Post> postSlice = postRepository.findLikedPostsByTimePeriod(timePeriod, pageRequest);
+        Slice<Post> postSlice = postQueryRepository.findLikedPostsByTimePeriod(timePeriod, pageRequest);
 
         //then
         assertAll(
@@ -99,7 +107,7 @@ class PostQueryRepositoryImplTest extends RepositoryTest {
 
         int pageSize = 20;
         PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.Direction.ASC, "createdAt");
-        Slice<Post> posts = postRepository.findByUserNicknameAndHashtag(user.getNickname(), null, pageRequest);
+        Slice<Post> posts = postQueryRepository.findByUserNicknameAndHashtag(user.getNickname(), null, pageRequest);
 
         assertThat(posts.getSize()).isEqualTo(pageSize);
         assertThat(posts.hasNext()).isTrue();
@@ -115,7 +123,7 @@ class PostQueryRepositoryImplTest extends RepositoryTest {
 
         int pageSize = 20;
         PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.Direction.ASC, "createdAt");
-        Slice<Post> posts = postRepository.findByUserNicknameAndHashtag(null, "해쉬태그", pageRequest);
+        Slice<Post> posts = postQueryRepository.findByUserNicknameAndHashtag(null, "해쉬태그", pageRequest);
 
         assertThat(posts.getNumberOfElements()).isEqualTo(postHashtags.size());
         assertThat(posts.hasNext()).isFalse();
@@ -131,7 +139,7 @@ class PostQueryRepositoryImplTest extends RepositoryTest {
 
         int pageSize = 20;
         PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.Direction.ASC, "createdAt");
-        Slice<Post> posts = postRepository.findByUserNicknameAndHashtag(user.getNickname(), "해쉬태그", pageRequest);
+        Slice<Post> posts = postQueryRepository.findByUserNicknameAndHashtag(user.getNickname(), "해쉬태그", pageRequest);
 
         assertThat(posts.getNumberOfElements()).isEqualTo(postHashtags.size());
         assertThat(posts.hasNext()).isFalse();

--- a/src/test/java/dev/backlog/domain/post/infra/jpa/PostRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/post/infra/jpa/PostRepositoryTest.java
@@ -1,4 +1,4 @@
-package dev.backlog.domain.post.infrastructure.persistence;
+package dev.backlog.domain.post.infra.jpa;
 
 import dev.backlog.common.RepositoryTest;
 import dev.backlog.domain.like.infrastructure.persistence.LikeRepository;
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class PostRepositoryTest extends RepositoryTest {
 
     @Autowired
-    private PostRepository postRepository;
+    private PostJpaRepository postRepository;
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -148,7 +148,7 @@ class PostServiceTest extends TestContainerConfig {
                 "/path"
         );
 
-        AuthInfo authInfo = new AuthInfo(유저1.getId());
+        AuthInfo authInfo = new AuthInfo(user.getId());
         Long postId = postService.create(request, authInfo);
 
         assertThat(postId).isNotNull();

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -17,6 +17,7 @@ import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.PostHashtag;
 import dev.backlog.domain.series.infrastructure.persistence.SeriesRepository;
 import dev.backlog.domain.series.model.Series;
+import dev.backlog.domain.user.dto.AuthInfo;
 import dev.backlog.domain.user.infrastructure.persistence.UserRepository;
 import dev.backlog.domain.user.model.User;
 import org.assertj.core.api.Assertions;
@@ -147,7 +148,9 @@ class PostServiceTest extends TestContainerConfig {
                 "/path"
         );
 
-        Long postId = postService.create(request, user.getId());
+        AuthInfo authInfo = new AuthInfo(유저1.getId());
+        Long postId = postService.create(request, authInfo);
+
         assertThat(postId).isNotNull();
     }
 

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -11,8 +11,8 @@ import dev.backlog.domain.post.dto.PostResponse;
 import dev.backlog.domain.post.dto.PostSliceResponse;
 import dev.backlog.domain.post.dto.PostSummaryResponse;
 import dev.backlog.domain.post.dto.PostUpdateRequest;
-import dev.backlog.domain.post.infrastructure.persistence.PostHashtagRepository;
-import dev.backlog.domain.post.infrastructure.persistence.PostRepository;
+import dev.backlog.domain.post.infra.jpa.PostHashtagRepository;
+import dev.backlog.domain.post.infra.jpa.PostJpaRepository;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.PostHashtag;
 import dev.backlog.domain.series.infrastructure.persistence.SeriesRepository;
@@ -55,7 +55,7 @@ class PostServiceTest extends TestContainerConfig {
     private UserRepository userRepository;
 
     @Autowired
-    private PostRepository postRepository;
+    private PostJpaRepository postRepository;
 
     @Autowired
     private CommentRepository commentRepository;


### PR DESCRIPTION
## 📄 Summary
>
- Post 도메인을 페어프로그래밍으로 리팩터링
- 레포지토리 DIP원칙 적용해서 분리
- Post생성 API Refactor
- Controller Methid Mapping 순서 컨벤션에 맞게 변경
- TokenArgumentResolver 적용

## 🍸 More
> 
- Post 도메인을 페어프로그래밍으로 리팩터링
- 레포지토리 DIP원칙 적용해서 분리
- Post생성 API Refactor
- Controller Methid Mapping 순서 컨벤션에 맞게 변경
- TokenArgumentResolver 적용
