### PR TITLE
유저, 해시태그, 포스트해시태그 어뎁터로 분리

### DIFF
--- a/src/main/java/dev/backlog/domain/hashtag/infrastructure/HashtagRepositoryAdapter.java
+++ b/src/main/java/dev/backlog/domain/hashtag/infrastructure/HashtagRepositoryAdapter.java
@@ -1,0 +1,38 @@
+package dev.backlog.domain.hashtag.infrastructure;
+
+import dev.backlog.domain.hashtag.infrastructure.jpa.HashtagJpaRepository;
+import dev.backlog.domain.hashtag.model.Hashtag;
+import dev.backlog.domain.hashtag.model.repository.HashtagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class HashtagRepositoryAdapter implements HashtagRepository {
+
+    private final HashtagJpaRepository hashtagJpaRepository;
+
+    @Override
+    public Hashtag save(Hashtag hashtag) {
+        return hashtagJpaRepository.save(hashtag);
+    }
+
+    @Override
+    public Optional<Hashtag> findByName(String hashtag) {
+        return hashtagJpaRepository.findByName(hashtag);
+    }
+
+    @Override
+    public List<Hashtag> saveAll(Iterable<Hashtag> hashtags) {
+        return hashtagJpaRepository.saveAll(hashtags);
+    }
+
+    @Override
+    public void deleteAll() {
+        hashtagJpaRepository.deleteAll();
+    }
+
+}

--- a/src/main/java/dev/backlog/domain/hashtag/infrastructure/jpa/HashtagJpaRepository.java
+++ b/src/main/java/dev/backlog/domain/hashtag/infrastructure/jpa/HashtagJpaRepository.java
@@ -1,4 +1,4 @@
-package dev.backlog.domain.hashtag.infrastructure.persistence;
+package dev.backlog.domain.hashtag.infrastructure.jpa;
 
 import dev.backlog.domain.hashtag.model.Hashtag;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/dev/backlog/domain/hashtag/model/repository/HashtagRepository.java
+++ b/src/main/java/dev/backlog/domain/hashtag/model/repository/HashtagRepository.java
@@ -1,0 +1,18 @@
+package dev.backlog.domain.hashtag.model.repository;
+
+import dev.backlog.domain.hashtag.model.Hashtag;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HashtagRepository {
+
+    Hashtag save(Hashtag hashtag);
+
+    Optional<Hashtag> findByName(String hashtag);
+
+    List<Hashtag> saveAll(Iterable<Hashtag> entities);
+
+    void deleteAll();
+
+}

--- a/src/main/java/dev/backlog/domain/post/service/PostHashtagService.java
+++ b/src/main/java/dev/backlog/domain/post/service/PostHashtagService.java
@@ -1,7 +1,7 @@
 package dev.backlog.domain.post.service;
 
-import dev.backlog.domain.hashtag.infrastructure.persistence.HashtagJpaRepository;
 import dev.backlog.domain.hashtag.model.Hashtag;
+import dev.backlog.domain.hashtag.model.repository.HashtagRepository;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.PostHashtag;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ import static java.util.stream.Collectors.toCollection;
 @RequiredArgsConstructor
 public class PostHashtagService {
 
-    private final HashtagJpaRepository hashtagJpaRepository;
+    private final HashtagRepository hashtagRepository;
 
     public void associatePostWithHashtags(List<String> names, Post post) {
         if (names == null || names.isEmpty()) {
@@ -37,8 +37,8 @@ public class PostHashtagService {
     }
 
     private Hashtag findOrCreate(String hashtag) {
-        return hashtagJpaRepository.findByName(hashtag)
-                .orElseGet(() -> hashtagJpaRepository.save(new Hashtag(hashtag)));
+        return hashtagRepository.findByName(hashtag)
+                .orElseGet(() -> hashtagRepository.save(new Hashtag(hashtag)));
     }
 
 }

--- a/src/main/java/dev/backlog/domain/post/service/query/PostQueryService.java
+++ b/src/main/java/dev/backlog/domain/post/service/query/PostQueryService.java
@@ -14,8 +14,8 @@ import dev.backlog.domain.post.model.repository.PostRepository;
 import dev.backlog.domain.series.model.Series;
 import dev.backlog.domain.series.model.repository.SeriesRepository;
 import dev.backlog.domain.user.dto.AuthInfo;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -32,7 +32,7 @@ public class PostQueryService {
     private final PostRepository postRepository;
     private final PostQueryRepository postQueryRepository;
     private final PostCacheRepository postCacheRepository;
-    private final UserJpaRepository userJpaRepository;
+    private final UserRepository userRepository;
     private final SeriesRepository seriesRepository;
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
@@ -55,8 +55,7 @@ public class PostQueryService {
     }
 
     public PostSliceResponse<PostSummaryResponse> findLikedPostsByUser(AuthInfo authInfo, Pageable pageable) {
-        User user = userJpaRepository.findById(authInfo.userId())
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+        User user = userRepository.getById(authInfo.userId());
 
         Slice<PostSummaryResponse> postSummaryResponses = postRepository.findLikedPostsByUserId(user.getId(), pageable)
                 .map(this::createPostSummaryResponse);
@@ -64,8 +63,7 @@ public class PostQueryService {
     }
 
     public PostSliceResponse<PostSummaryResponse> findPostsByUserAndSeries(String nickname, String seriesName, Pageable pageable) {
-        User user = userJpaRepository.findByNickname(nickname)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+        User user = userRepository.getByNickname(nickname);
         Series series = seriesRepository.getByUserAndName(user, seriesName);
         Slice<PostSummaryResponse> postSummaryResponses = postRepository.findAllByUserAndSeries(user, series, pageable)
                 .map(this::createPostSummaryResponse);

--- a/src/main/java/dev/backlog/domain/user/infrastructure/UserRepositoryAdapter.java
+++ b/src/main/java/dev/backlog/domain/user/infrastructure/UserRepositoryAdapter.java
@@ -1,0 +1,51 @@
+package dev.backlog.domain.user.infrastructure;
+
+import dev.backlog.domain.auth.model.oauth.OAuthProvider;
+import dev.backlog.domain.user.infrastructure.jpa.UserJpaRepository;
+import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryAdapter implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public User save(User user) {
+        return userJpaRepository.save(user);
+    }
+
+    @Override
+    public List<User> saveAll(Iterable<User> user) {
+        return userJpaRepository.saveAll(user);
+    }
+
+    @Override
+    public User getById(Long userId) {
+        return userJpaRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자는 찾을 수 없습니다."));
+    }
+
+    @Override
+    public User getByOauthProviderIdAndOauthProvider(String oauthProviderId, OAuthProvider oauthProvider) {
+        return userJpaRepository.findByOauthProviderIdAndOauthProvider(oauthProviderId, oauthProvider)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자는 존재하지 않습니다. 회원가입을 먼저 진행해주세요."));
+    }
+
+    @Override
+    public User getByNickname(String nickname) {
+        return userJpaRepository.findByNickname(nickname)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+    }
+
+    @Override
+    public void deleteAll() {
+        userJpaRepository.deleteAll();
+    }
+
+}

--- a/src/main/java/dev/backlog/domain/user/infrastructure/UserRepositoryAdapter.java
+++ b/src/main/java/dev/backlog/domain/user/infrastructure/UserRepositoryAdapter.java
@@ -28,7 +28,7 @@ public class UserRepositoryAdapter implements UserRepository {
     @Override
     public User getById(Long userId) {
         return userJpaRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자는 찾을 수 없습니다."));
+                .orElseThrow(() -> new RuntimeException("해당 사용자는 찾을 수 없습니다."));
     }
 
     @Override

--- a/src/main/java/dev/backlog/domain/user/infrastructure/jpa/UserJpaRepository.java
+++ b/src/main/java/dev/backlog/domain/user/infrastructure/jpa/UserJpaRepository.java
@@ -1,4 +1,4 @@
-package dev.backlog.domain.user.infrastructure.persistence;
+package dev.backlog.domain.user.infrastructure.jpa;
 
 import dev.backlog.domain.auth.model.oauth.OAuthProvider;
 import dev.backlog.domain.user.model.User;

--- a/src/main/java/dev/backlog/domain/user/model/repository/UserRepository.java
+++ b/src/main/java/dev/backlog/domain/user/model/repository/UserRepository.java
@@ -1,0 +1,22 @@
+package dev.backlog.domain.user.model.repository;
+
+import dev.backlog.domain.auth.model.oauth.OAuthProvider;
+import dev.backlog.domain.user.model.User;
+
+import java.util.List;
+
+public interface UserRepository {
+
+    User save(User user);
+
+    User getById(Long userId);
+
+    User getByNickname(String nickname);
+
+    User getByOauthProviderIdAndOauthProvider(String oauthProviderId, OAuthProvider oauthProvider);
+
+    List<User> saveAll(Iterable<User> user);
+
+    void deleteAll();
+
+}

--- a/src/main/java/dev/backlog/domain/user/service/UserService.java
+++ b/src/main/java/dev/backlog/domain/user/service/UserService.java
@@ -3,8 +3,8 @@ package dev.backlog.domain.user.service;
 import dev.backlog.domain.user.dto.UserDetailsResponse;
 import dev.backlog.domain.user.dto.UserResponse;
 import dev.backlog.domain.user.dto.UserUpdateRequest;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,24 +14,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserService {
 
-    private final UserJpaRepository userJpaRepository;
+    private final UserRepository userRepository;
 
     public UserResponse findUserProfile(String nickname) {
-        User user = userJpaRepository.findByNickname(nickname)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자는 찾을 수 없습니다."));
+        User user = userRepository.getByNickname(nickname);
         return UserResponse.from(user);
     }
 
     public UserDetailsResponse findMyProfile(Long userId) {
-        User user = userJpaRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자는 찾을 수 없습니다."));
+        User user = userRepository.getById(userId);
         return UserDetailsResponse.from(user);
     }
 
     @Transactional
     public void updateProfile(UserUpdateRequest request, Long userId) {
-        User user = userJpaRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자는 찾을 수 없습니다."));
+        User user = userRepository.getById(userId);
         updateUserByRequest(user, request);
     }
 

--- a/src/test/java/dev/backlog/common/RepositoryTestConfig.java
+++ b/src/test/java/dev/backlog/common/RepositoryTestConfig.java
@@ -6,6 +6,9 @@ import dev.backlog.common.config.QueryDslConfig;
 import dev.backlog.domain.comment.infra.CommentRepositoryAdaptor;
 import dev.backlog.domain.comment.infra.jpa.CommentJpaRepository;
 import dev.backlog.domain.comment.model.repository.CommentRepository;
+import dev.backlog.domain.hashtag.infrastructure.HashtagRepositoryAdapter;
+import dev.backlog.domain.hashtag.infrastructure.jpa.HashtagJpaRepository;
+import dev.backlog.domain.hashtag.model.repository.HashtagRepository;
 import dev.backlog.domain.like.infra.LikeRepositoryAdaptor;
 import dev.backlog.domain.like.infra.jpa.LikeJpaRepository;
 import dev.backlog.domain.like.model.repository.LikeRepository;
@@ -26,8 +29,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
-@Import(value = {QueryDslConfig.class, JpaConfig.class, RepositoryTest.RepositoryAdaptorTestConfig.class})
-public class RepositoryTest {
+@Import(value = {QueryDslConfig.class, JpaConfig.class, RepositoryTestConfig.RepositoryAdaptorTestConfig.class})
+public class RepositoryTestConfig {
 
     @TestConfiguration
     static class RepositoryAdaptorTestConfig {
@@ -60,6 +63,11 @@ public class RepositoryTest {
         @Bean
         public LikeRepository likeRepository(LikeJpaRepository likeJpaRepository) {
             return new LikeRepositoryAdaptor(likeJpaRepository);
+        }
+
+        @Bean
+        public HashtagRepository hashtagRepository(HashtagJpaRepository hashtagJpaRepository) {
+            return new HashtagRepositoryAdapter(hashtagJpaRepository);
         }
 
     }

--- a/src/test/java/dev/backlog/common/RepositoryTestConfig.java
+++ b/src/test/java/dev/backlog/common/RepositoryTestConfig.java
@@ -74,7 +74,7 @@ public class RepositoryTestConfig {
         }
 
         @Bean
-        public UserRepository hashtagRepository(UserJpaRepository userJpaRepository) {
+        public UserRepository userRepository(UserJpaRepository userJpaRepository) {
             return new UserRepositoryAdapter(userJpaRepository);
         }
 

--- a/src/test/java/dev/backlog/common/RepositoryTestConfig.java
+++ b/src/test/java/dev/backlog/common/RepositoryTestConfig.java
@@ -23,6 +23,9 @@ import dev.backlog.domain.post.model.repository.PostRepository;
 import dev.backlog.domain.series.infra.SeriesRepositoryAdaptor;
 import dev.backlog.domain.series.infra.jpa.SeriesJpaRepository;
 import dev.backlog.domain.series.model.repository.SeriesRepository;
+import dev.backlog.domain.user.infrastructure.UserRepositoryAdapter;
+import dev.backlog.domain.user.infrastructure.jpa.UserJpaRepository;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -68,6 +71,11 @@ public class RepositoryTestConfig {
         @Bean
         public HashtagRepository hashtagRepository(HashtagJpaRepository hashtagJpaRepository) {
             return new HashtagRepositoryAdapter(hashtagJpaRepository);
+        }
+
+        @Bean
+        public UserRepository hashtagRepository(UserJpaRepository userJpaRepository) {
+            return new UserRepositoryAdapter(userJpaRepository);
         }
 
     }

--- a/src/test/java/dev/backlog/domain/auth/service/OAuthServiceTest.java
+++ b/src/test/java/dev/backlog/domain/auth/service/OAuthServiceTest.java
@@ -12,6 +12,7 @@ import dev.backlog.domain.auth.model.oauth.dto.OAuthInfoResponse;
 import dev.backlog.domain.auth.model.oauth.dto.SignupRequest;
 import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +35,7 @@ class OAuthServiceTest {
     private OAuthService oAuthService;
 
     @Mock
-    private UserJpaRepository userJpaRepository;
+    private UserRepository userRepository;
 
     @Mock
     private AuthCodeRequestUrlProviderComposite authCodeRequestUrlProviderComposite;
@@ -67,7 +68,7 @@ class OAuthServiceTest {
         OAuthInfoResponse response = createOAuthInfoResponse(newUser);
 
         when(oAuthMemberClientComposite.fetch(signupRequest.oAuthProvider(), signupRequest.authCode())).thenReturn(response);
-        when(userJpaRepository.save(any())).thenReturn(newUser);
+        when(userRepository.save(any())).thenReturn(newUser);
         when(authTokensGenerator.generate(newUser.getId())).thenReturn(authToken);
 
         AuthTokens authTokens = oAuthService.signup(signupRequest);
@@ -88,7 +89,7 @@ class OAuthServiceTest {
         AuthTokens expectedToken = 토큰생성();
 
         when(oAuthMemberClientComposite.fetch(any(), any())).thenReturn(response);
-        when(userJpaRepository.findByOauthProviderIdAndOauthProvider(user.getOauthProviderId(), user.getOauthProvider())).thenReturn(Optional.of(user));
+        when(userRepository.getByOauthProviderIdAndOauthProvider(user.getOauthProviderId(), user.getOauthProvider())).thenReturn(user);
         when(authTokensGenerator.generate(user.getId())).thenReturn(expectedToken);
 
         AuthTokens authTokens = oAuthService.login(OAuthProvider.KAKAO, "authCode");

--- a/src/test/java/dev/backlog/domain/auth/service/OAuthServiceTest.java
+++ b/src/test/java/dev/backlog/domain/auth/service/OAuthServiceTest.java
@@ -10,7 +10,6 @@ import dev.backlog.domain.auth.model.oauth.authcode.AuthCodeRequestUrlProviderCo
 import dev.backlog.domain.auth.model.oauth.client.OAuthMemberClientComposite;
 import dev.backlog.domain.auth.model.oauth.dto.OAuthInfoResponse;
 import dev.backlog.domain.auth.model.oauth.dto.SignupRequest;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
 import dev.backlog.domain.user.model.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -19,8 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
 
 import static dev.backlog.common.fixture.DtoFixture.토큰생성;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/dev/backlog/domain/comment/model/repository/CommentRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/comment/model/repository/CommentRepositoryTest.java
@@ -1,6 +1,6 @@
 package dev.backlog.domain.comment.model.repository;
 
-import dev.backlog.common.RepositoryTest;
+import dev.backlog.common.RepositoryTestConfig;
 import dev.backlog.domain.comment.model.Comment;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.repository.PostRepository;
@@ -17,7 +17,7 @@ import static dev.backlog.common.fixture.EntityFixture.댓글1;
 import static dev.backlog.common.fixture.EntityFixture.유저1;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CommentRepositoryTest extends RepositoryTest {
+class CommentRepositoryTest extends RepositoryTestConfig {
 
     @Autowired
     private CommentRepository commentRepository;

--- a/src/test/java/dev/backlog/domain/comment/model/repository/CommentRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/comment/model/repository/CommentRepositoryTest.java
@@ -4,8 +4,8 @@ import dev.backlog.common.RepositoryTestConfig;
 import dev.backlog.domain.comment.model.Comment;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.repository.PostRepository;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,13 +26,13 @@ class CommentRepositoryTest extends RepositoryTestConfig {
     private PostRepository postRepository;
 
     @Autowired
-    private UserJpaRepository userJpaRepository;
+    private UserRepository userRepository;
 
     @DisplayName("모든 댓글을 저장할 수 있다.")
     @Test
     void saveAllTest() {
         //given
-        User user = userJpaRepository.save(유저1());
+        User user = userRepository.save(유저1());
         Post post = postRepository.save(게시물1(user, null));
         List<Comment> comments = List.of(댓글1(user, post), 댓글1(user, post));
 
@@ -47,7 +47,7 @@ class CommentRepositoryTest extends RepositoryTestConfig {
     @Test
     void findAllByPostTest() {
         //given
-        User user = userJpaRepository.save(유저1());
+        User user = userRepository.save(유저1());
         Post post = postRepository.save(게시물1(user, null));
         commentRepository.saveAll(List.of(댓글1(user, post), 댓글1(user, post)));
 
@@ -63,7 +63,7 @@ class CommentRepositoryTest extends RepositoryTestConfig {
     @Test
     void countByPostTest() {
         //given
-        User user = userJpaRepository.save(유저1());
+        User user = userRepository.save(유저1());
         Post post = postRepository.save(게시물1(user, null));
         List<Comment> comments = List.of(댓글1(user, post), 댓글1(user, post));
         commentRepository.saveAll(comments);
@@ -79,7 +79,7 @@ class CommentRepositoryTest extends RepositoryTestConfig {
     @Test
     void deleteAllTest() {
         //given
-        User user = userJpaRepository.save(유저1());
+        User user = userRepository.save(유저1());
         Post post = postRepository.save(게시물1(user, null));
         List<Comment> comments = List.of(댓글1(user, post), 댓글1(user, post));
         commentRepository.saveAll(comments);

--- a/src/test/java/dev/backlog/domain/hashtag/infrastructure/HashtagRepositoryAdapterTest.java
+++ b/src/test/java/dev/backlog/domain/hashtag/infrastructure/HashtagRepositoryAdapterTest.java
@@ -1,17 +1,18 @@
-package dev.backlog.domain.hashtag.infrastructure.persistence;
+package dev.backlog.domain.hashtag.infrastructure;
 
-import dev.backlog.common.RepositoryTest;
+import dev.backlog.common.RepositoryTestConfig;
 import dev.backlog.domain.hashtag.model.Hashtag;
+import dev.backlog.domain.hashtag.model.repository.HashtagRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class HashtagJpaRepositoryTest extends RepositoryTest {
+class HashtagRepositoryAdapterTest extends RepositoryTestConfig {
 
     @Autowired
-    private HashtagJpaRepository hashtagJpaRepository;
+    private HashtagRepository hashtagRepository;
 
     @DisplayName("해쉬태그의 이름으로 해쉬태그를 찾을 수 있다.")
     @Test
@@ -19,8 +20,8 @@ class HashtagJpaRepositoryTest extends RepositoryTest {
         String 해쉬태그 = "해쉬태그";
         Hashtag hashtag = new Hashtag(해쉬태그);
 
-        Hashtag savedHashtag = hashtagJpaRepository.save(hashtag);
-        Hashtag foundHashtag = hashtagJpaRepository.findByName(해쉬태그).get();
+        Hashtag savedHashtag = hashtagRepository.save(hashtag);
+        Hashtag foundHashtag = hashtagRepository.findByName(해쉬태그).get();
 
         assertThat(foundHashtag).isEqualTo(savedHashtag);
     }

--- a/src/test/java/dev/backlog/domain/like/model/repository/LikeRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/like/model/repository/LikeRepositoryTest.java
@@ -4,8 +4,8 @@ import dev.backlog.common.RepositoryTestConfig;
 import dev.backlog.domain.like.model.Like;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.repository.PostRepository;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +23,7 @@ class LikeRepositoryTest extends RepositoryTestConfig {
     private LikeRepository likeRepository;
 
     @Autowired
-    private UserJpaRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private PostRepository postRepository;

--- a/src/test/java/dev/backlog/domain/like/model/repository/LikeRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/like/model/repository/LikeRepositoryTest.java
@@ -1,6 +1,6 @@
 package dev.backlog.domain.like.model.repository;
 
-import dev.backlog.common.RepositoryTest;
+import dev.backlog.common.RepositoryTestConfig;
 import dev.backlog.domain.like.model.Like;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.repository.PostRepository;
@@ -17,7 +17,7 @@ import static dev.backlog.common.fixture.EntityFixture.유저1;
 import static dev.backlog.common.fixture.EntityFixture.좋아요1;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class LikeRepositoryTest extends RepositoryTest {
+class LikeRepositoryTest extends RepositoryTestConfig {
 
     @Autowired
     private LikeRepository likeRepository;

--- a/src/test/java/dev/backlog/domain/post/infra/jpa/PostHashtagJpaRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/post/infra/jpa/PostHashtagJpaRepositoryTest.java
@@ -1,8 +1,8 @@
 package dev.backlog.domain.post.infra.jpa;
 
-import dev.backlog.common.RepositoryTest;
-import dev.backlog.domain.hashtag.infrastructure.persistence.HashtagJpaRepository;
+import dev.backlog.common.RepositoryTestConfig;
 import dev.backlog.domain.hashtag.model.Hashtag;
+import dev.backlog.domain.hashtag.model.repository.HashtagRepository;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.PostHashtag;
 import dev.backlog.domain.post.model.repository.PostHashtagRepository;
@@ -21,7 +21,7 @@ import static dev.backlog.common.fixture.EntityFixture.해쉬태그_모음;
 import static org.assertj.core.api.Assertions.assertThat;
 
 // TODO: 2023/09/11 테스트 경로 수정 및 분리
-class PostHashtagJpaRepositoryTest extends RepositoryTest {
+class PostHashtagJpaRepositoryTest extends RepositoryTestConfig {
 
     @Autowired
     private PostHashtagRepository postHashtagRepository;
@@ -33,7 +33,7 @@ class PostHashtagJpaRepositoryTest extends RepositoryTest {
     private PostJpaRepository postRepository;
 
     @Autowired
-    private HashtagJpaRepository hashtagJpaRepository;
+    private HashtagRepository hashtagRepository;
 
     private User 유저1;
     private Post 게시물1;
@@ -43,7 +43,7 @@ class PostHashtagJpaRepositoryTest extends RepositoryTest {
     void setUp() {
         유저1 = userJpaRepository.save(유저1());
         게시물1 = postRepository.save(게시물1(유저1, null));
-        해쉬태그_모음 = hashtagJpaRepository.saveAll(해쉬태그_모음());
+        해쉬태그_모음 = hashtagRepository.saveAll(해쉬태그_모음());
     }
 
     @DisplayName("PostHashtag에서 Post를 찾아 PostHashtag를 삭제한다.")

--- a/src/test/java/dev/backlog/domain/post/infra/jpa/PostHashtagJpaRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/post/infra/jpa/PostHashtagJpaRepositoryTest.java
@@ -6,8 +6,8 @@ import dev.backlog.domain.hashtag.model.repository.HashtagRepository;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.PostHashtag;
 import dev.backlog.domain.post.model.repository.PostHashtagRepository;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ class PostHashtagJpaRepositoryTest extends RepositoryTestConfig {
     private PostHashtagRepository postHashtagRepository;
 
     @Autowired
-    private UserJpaRepository userJpaRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private PostJpaRepository postRepository;
@@ -41,7 +41,7 @@ class PostHashtagJpaRepositoryTest extends RepositoryTestConfig {
 
     @BeforeEach
     void setUp() {
-        유저1 = userJpaRepository.save(유저1());
+        유저1 = userRepository.save(유저1());
         게시물1 = postRepository.save(게시물1(유저1, null));
         해쉬태그_모음 = hashtagRepository.saveAll(해쉬태그_모음());
     }

--- a/src/test/java/dev/backlog/domain/post/model/repository/PostQueryRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/post/model/repository/PostQueryRepositoryTest.java
@@ -1,8 +1,8 @@
 package dev.backlog.domain.post.model.repository;
 
-import dev.backlog.common.RepositoryTest;
-import dev.backlog.domain.hashtag.infrastructure.persistence.HashtagJpaRepository;
+import dev.backlog.common.RepositoryTestConfig;
 import dev.backlog.domain.hashtag.model.Hashtag;
+import dev.backlog.domain.hashtag.model.repository.HashtagRepository;
 import dev.backlog.domain.like.model.Like;
 import dev.backlog.domain.like.model.repository.LikeRepository;
 import dev.backlog.domain.post.model.Post;
@@ -30,7 +30,7 @@ import static dev.backlog.common.fixture.EntityFixture.해쉬태그_모음;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-class PostQueryRepositoryTest extends RepositoryTest {
+class PostQueryRepositoryTest extends RepositoryTestConfig {
 
     @Autowired
     PostRepository postRepository;
@@ -45,7 +45,7 @@ class PostQueryRepositoryTest extends RepositoryTest {
     LikeRepository likeRepository;
 
     @Autowired
-    HashtagJpaRepository hashtagJpaRepository;
+    HashtagRepository hashtagRepository;
 
     @Autowired
     PostHashtagRepository postHashtagRepository;
@@ -110,7 +110,7 @@ class PostQueryRepositoryTest extends RepositoryTest {
     @Test
     void findByHashtagTest() {
         User user = userJpaRepository.save(유저1);
-        Hashtag hashtag = hashtagJpaRepository.save(해쉬태그);
+        Hashtag hashtag = hashtagRepository.save(해쉬태그);
         List<Post> savedPosts = postRepository.saveAll(게시물_모음(user, null));
         List<PostHashtag> postHashtags = createPostHashtags(hashtag, savedPosts);
 
@@ -126,7 +126,7 @@ class PostQueryRepositoryTest extends RepositoryTest {
     @Test
     void findByNicknameAndHashtagTest() {
         User user = userJpaRepository.save(유저1);
-        Hashtag hashtag = hashtagJpaRepository.save(해쉬태그);
+        Hashtag hashtag = hashtagRepository.save(해쉬태그);
         List<Post> savedPosts = postRepository.saveAll(게시물_모음(user, null));
         List<PostHashtag> postHashtags = createPostHashtags(hashtag, savedPosts);
 

--- a/src/test/java/dev/backlog/domain/post/model/repository/PostQueryRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/post/model/repository/PostQueryRepositoryTest.java
@@ -7,8 +7,8 @@ import dev.backlog.domain.like.model.Like;
 import dev.backlog.domain.like.model.repository.LikeRepository;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.post.model.PostHashtag;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,7 +39,7 @@ class PostQueryRepositoryTest extends RepositoryTestConfig {
     PostQueryRepository postQueryRepository;
 
     @Autowired
-    UserJpaRepository userJpaRepository;
+    UserRepository userRepository;
 
     @Autowired
     LikeRepository likeRepository;
@@ -66,7 +66,7 @@ class PostQueryRepositoryTest extends RepositoryTestConfig {
         //given
         User user1 = 유저1();
         User user2 = 유저1();
-        userJpaRepository.saveAll(List.of(user1, user2));
+        userRepository.saveAll(List.of(user1, user2));
 
         Post post1 = 게시물1(user1, null);
         Post post2 = 게시물1(user1, null);
@@ -95,7 +95,7 @@ class PostQueryRepositoryTest extends RepositoryTestConfig {
     @DisplayName("닉네임을 통해 게시물을 조회할 수 있다.")
     @Test
     void findByNicknameTest() {
-        User user = userJpaRepository.save(유저1);
+        User user = userRepository.save(유저1);
         postRepository.saveAll(게시물_모음(user, null));
 
         int pageSize = 20;
@@ -109,7 +109,7 @@ class PostQueryRepositoryTest extends RepositoryTestConfig {
     @DisplayName("해쉬태그를 통해 게시물을 조회할 수 있다.")
     @Test
     void findByHashtagTest() {
-        User user = userJpaRepository.save(유저1);
+        User user = userRepository.save(유저1);
         Hashtag hashtag = hashtagRepository.save(해쉬태그);
         List<Post> savedPosts = postRepository.saveAll(게시물_모음(user, null));
         List<PostHashtag> postHashtags = createPostHashtags(hashtag, savedPosts);
@@ -125,7 +125,7 @@ class PostQueryRepositoryTest extends RepositoryTestConfig {
     @DisplayName("닉네임과 해쉬태그를 통해 게시물을 조회할 수 있다.")
     @Test
     void findByNicknameAndHashtagTest() {
-        User user = userJpaRepository.save(유저1);
+        User user = userRepository.save(유저1);
         Hashtag hashtag = hashtagRepository.save(해쉬태그);
         List<Post> savedPosts = postRepository.saveAll(게시물_모음(user, null));
         List<PostHashtag> postHashtags = createPostHashtags(hashtag, savedPosts);

--- a/src/test/java/dev/backlog/domain/post/model/repository/PostRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/post/model/repository/PostRepositoryTest.java
@@ -1,6 +1,6 @@
 package dev.backlog.domain.post.model.repository;
 
-import dev.backlog.common.RepositoryTest;
+import dev.backlog.common.RepositoryTestConfig;
 import dev.backlog.domain.like.model.Like;
 import dev.backlog.domain.like.model.repository.LikeRepository;
 import dev.backlog.domain.post.model.Post;
@@ -26,7 +26,7 @@ import static dev.backlog.common.fixture.EntityFixture.좋아요1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-class PostRepositoryTest extends RepositoryTest {
+class PostRepositoryTest extends RepositoryTestConfig {
 
     @Autowired
     private PostRepository postRepository;

--- a/src/test/java/dev/backlog/domain/post/model/repository/PostRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/post/model/repository/PostRepositoryTest.java
@@ -6,8 +6,8 @@ import dev.backlog.domain.like.model.repository.LikeRepository;
 import dev.backlog.domain.post.model.Post;
 import dev.backlog.domain.series.model.Series;
 import dev.backlog.domain.series.model.repository.SeriesRepository;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,7 +32,7 @@ class PostRepositoryTest extends RepositoryTestConfig {
     private PostRepository postRepository;
 
     @Autowired
-    private UserJpaRepository userJpaRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private LikeRepository likeRepository;
@@ -54,14 +54,14 @@ class PostRepositoryTest extends RepositoryTestConfig {
         likeRepository.deleteAll();
         postRepository.deleteAll();
         seriesRepository.deleteAll();
-        userJpaRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @DisplayName("공개된 게시글 중에서 특정 사용자가 남의 글에 좋아요를 누른 글들을 조회할 수 있다.")
     @Test
     void findLikedPostsByUserIdTest() {
         //given
-        User user = userJpaRepository.save(유저1);
+        User user = userRepository.save(유저1);
 
         List<Post> posts = postRepository.saveAll(게시물_모음);
         for (Post post : posts) {
@@ -85,7 +85,7 @@ class PostRepositoryTest extends RepositoryTestConfig {
     @Test
     void findAllByUserAndSeriesTest() {
         //given
-        User user = userJpaRepository.save(유저1);
+        User user = userRepository.save(유저1);
         Series series = seriesRepository.save(시리즈1(user));
         postRepository.saveAll(게시물_모음(user, series));
 

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import dev.backlog.common.config.TestContainerConfig;
 import dev.backlog.domain.comment.model.repository.CommentRepository;
-import dev.backlog.domain.hashtag.infrastructure.persistence.HashtagJpaRepository;
+import dev.backlog.domain.hashtag.model.repository.HashtagRepository;
 import dev.backlog.domain.like.model.repository.LikeRepository;
 import dev.backlog.domain.post.dto.PostCreateRequest;
 import dev.backlog.domain.post.dto.PostUpdateRequest;
@@ -57,7 +57,7 @@ class PostServiceTest extends TestContainerConfig {
     private PostHashtagRepository postHashtagRepository;
 
     @Autowired
-    private HashtagJpaRepository hashtagJpaRepository;
+    private HashtagRepository hashtagRepository;
 
     private User 유저1;
     private Post 게시물1;
@@ -73,7 +73,7 @@ class PostServiceTest extends TestContainerConfig {
         likeRepository.deleteAll();
         commentRepository.deleteAll();
         postHashtagRepository.deleteAll();
-        hashtagJpaRepository.deleteAll();
+        hashtagRepository.deleteAll();
         postRepository.deleteAll();
         seriesRepository.deleteAll();
         userJpaRepository.deleteAll();

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -14,8 +14,8 @@ import dev.backlog.domain.post.model.repository.PostHashtagRepository;
 import dev.backlog.domain.post.model.repository.PostRepository;
 import dev.backlog.domain.series.model.repository.SeriesRepository;
 import dev.backlog.domain.user.dto.AuthInfo;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,7 +39,7 @@ class PostServiceTest extends TestContainerConfig {
     private PostService postService;
 
     @Autowired
-    private UserJpaRepository userJpaRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private PostRepository postRepository;
@@ -76,13 +76,13 @@ class PostServiceTest extends TestContainerConfig {
         hashtagRepository.deleteAll();
         postRepository.deleteAll();
         seriesRepository.deleteAll();
-        userJpaRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @DisplayName("포스트 생성요청과 유저의 아이디를 받아 게시물을 저장할 수 있다.")
     @Test
     void createTest() {
-        User user = userJpaRepository.save(유저1);
+        User user = userRepository.save(유저1);
 
         PostCreateRequest request = new PostCreateRequest(
                 null,
@@ -104,7 +104,7 @@ class PostServiceTest extends TestContainerConfig {
     @DisplayName("게시물 업데이트의 대한 정보를 받아서 게시물을 업데이트한다.")
     @Test
     void updatePostTest() {
-        User user = userJpaRepository.save(유저1);
+        User user = userRepository.save(유저1);
         Post post = postRepository.save(게시물1);
         PostUpdateRequest request = 게시물수정요청();
         AuthInfo authInfo = new AuthInfo(user.getId(), "토큰");
@@ -127,7 +127,7 @@ class PostServiceTest extends TestContainerConfig {
     @DisplayName("게시물 작성자는 게시물을 삭제할 수 있다.")
     @Test
     void deletePostTest() {
-        userJpaRepository.save(유저1);
+        userRepository.save(유저1);
         postRepository.save(게시물1);
         Long postId = 게시물1.getId();
         postService.deletePost(postId, 유저1.getId());
@@ -138,7 +138,7 @@ class PostServiceTest extends TestContainerConfig {
     @DisplayName("게시물 작성자가 아니면 게시물을 삭제할 수 없다.")
     @Test
     void deletePostFailTest() {
-        userJpaRepository.save(유저1);
+        userRepository.save(유저1);
         postRepository.save(게시물1);
         Long postId = 게시물1.getId();
         Long userId = 유저1.getId();

--- a/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/PostServiceTest.java
@@ -1,7 +1,5 @@
 package dev.backlog.domain.post.service;
 
-import java.util.List;
-import java.util.NoSuchElementException;
 import dev.backlog.common.config.TestContainerConfig;
 import dev.backlog.domain.comment.model.repository.CommentRepository;
 import dev.backlog.domain.hashtag.model.repository.HashtagRepository;
@@ -16,7 +14,6 @@ import dev.backlog.domain.series.model.repository.SeriesRepository;
 import dev.backlog.domain.user.dto.AuthInfo;
 import dev.backlog.domain.user.model.User;
 import dev.backlog.domain.user.model.repository.UserRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.List;
+import java.util.NoSuchElementException;
 
 import static dev.backlog.common.fixture.DtoFixture.게시물수정요청;
 import static dev.backlog.common.fixture.EntityFixture.게시물1;
@@ -142,8 +141,8 @@ class PostServiceTest extends TestContainerConfig {
         postRepository.save(게시물1);
         Long postId = 게시물1.getId();
         Long userId = 유저1.getId();
-        Assertions.assertThatThrownBy(() -> postService.deletePost(postId, userId + 1))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> postService.deletePost(postId, userId + 1))
+                .isInstanceOf(RuntimeException.class);
     }
 
 }

--- a/src/test/java/dev/backlog/domain/post/service/query/PostQueryServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/query/PostQueryServiceTest.java
@@ -96,7 +96,7 @@ class PostQueryServiceTest extends TestContainerConfig {
     void findPostByIdTest() {
         //given
         User user = userRepository.save(유저1);
-        AuthInfo authInfo = new AuthInfo(user.getId());
+        AuthInfo authInfo = new AuthInfo(user.getId(), "토큰");
         Post post = postRepository.save(게시물1);
         commentRepository.saveAll(댓글_모음);
 

--- a/src/test/java/dev/backlog/domain/post/service/query/PostQueryServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/query/PostQueryServiceTest.java
@@ -3,7 +3,7 @@ package dev.backlog.domain.post.service.query;
 import dev.backlog.common.config.TestContainerConfig;
 import dev.backlog.domain.comment.model.Comment;
 import dev.backlog.domain.comment.model.repository.CommentRepository;
-import dev.backlog.domain.hashtag.infrastructure.persistence.HashtagJpaRepository;
+import dev.backlog.domain.hashtag.model.repository.HashtagRepository;
 import dev.backlog.domain.like.model.Like;
 import dev.backlog.domain.like.model.repository.LikeRepository;
 import dev.backlog.domain.post.dto.PostResponse;
@@ -65,7 +65,7 @@ class PostQueryServiceTest extends TestContainerConfig {
     private PostHashtagRepository postHashtagRepository;
 
     @Autowired
-    private HashtagJpaRepository hashtagJpaRepository;
+    private HashtagRepository hashtagRepository;
 
     private User 유저1;
     private Post 게시물1;
@@ -85,7 +85,7 @@ class PostQueryServiceTest extends TestContainerConfig {
         likeRepository.deleteAll();
         commentRepository.deleteAll();
         postHashtagRepository.deleteAll();
-        hashtagJpaRepository.deleteAll();
+        hashtagRepository.deleteAll();
         postRepository.deleteAll();
         seriesRepository.deleteAll();
         userJpaRepository.deleteAll();

--- a/src/test/java/dev/backlog/domain/post/service/query/PostQueryServiceTest.java
+++ b/src/test/java/dev/backlog/domain/post/service/query/PostQueryServiceTest.java
@@ -15,8 +15,8 @@ import dev.backlog.domain.post.model.repository.PostRepository;
 import dev.backlog.domain.series.model.Series;
 import dev.backlog.domain.series.model.repository.SeriesRepository;
 import dev.backlog.domain.user.dto.AuthInfo;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -47,7 +47,7 @@ class PostQueryServiceTest extends TestContainerConfig {
     private PostQueryService postQueryService;
 
     @Autowired
-    private UserJpaRepository userJpaRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private PostRepository postRepository;
@@ -88,15 +88,15 @@ class PostQueryServiceTest extends TestContainerConfig {
         hashtagRepository.deleteAll();
         postRepository.deleteAll();
         seriesRepository.deleteAll();
-        userJpaRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @DisplayName("게시글을 상세 조회할 수 있다.")
     @Test
     void findPostByIdTest() {
         //given
-        User user = userJpaRepository.save(유저1);
-        AuthInfo authInfo = new AuthInfo(user.getId(), "토큰");
+        User user = userRepository.save(유저1);
+        AuthInfo authInfo = new AuthInfo(user.getId());
         Post post = postRepository.save(게시물1);
         commentRepository.saveAll(댓글_모음);
 
@@ -111,7 +111,7 @@ class PostQueryServiceTest extends TestContainerConfig {
     @Test
     void sameUserCannotIncreaseViewCountForSamePostWithin3Hours() {
         //given
-        User user = userJpaRepository.save(유저1);
+        User user = userRepository.save(유저1);
         AuthInfo authInfo = new AuthInfo(user.getId(), "토큰");
         Post post = postRepository.save(게시물1);
         commentRepository.saveAll(댓글_모음);
@@ -133,7 +133,7 @@ class PostQueryServiceTest extends TestContainerConfig {
     @Test
     void findLikedPostsByUserTest() {
         //given
-        User user = userJpaRepository.save(유저1);
+        User user = userRepository.save(유저1);
         AuthInfo authInfo = new AuthInfo(user.getId(), "토큰");
 
         List<Post> posts = postRepository.saveAll(게시물_모음);
@@ -159,7 +159,7 @@ class PostQueryServiceTest extends TestContainerConfig {
     @Test
     void findPostsByUserAndSeriesTest() {
         //given
-        User user = userJpaRepository.save(유저1);
+        User user = userRepository.save(유저1);
         Series series = seriesRepository.save(시리즈1(user));
         postRepository.saveAll(게시물_모음(user, series));
 
@@ -180,7 +180,7 @@ class PostQueryServiceTest extends TestContainerConfig {
     @Test
     void findPostsInLatestOrderTest() {
         //given
-        userJpaRepository.save(유저1);
+        userRepository.save(유저1);
         postRepository.saveAll(게시물_모음);
 
         PageRequest pageRequest = PageRequest.of(1, 20, Sort.Direction.DESC, "createdAt");
@@ -203,7 +203,7 @@ class PostQueryServiceTest extends TestContainerConfig {
         //given
         User user1 = 유저1();
         User user2 = 유저1();
-        userJpaRepository.saveAll(List.of(user1, user2));
+        userRepository.saveAll(List.of(user1, user2));
 
         Post post1 = 게시물1(user1, null);
         Post post2 = 게시물1(user1, null);
@@ -231,7 +231,7 @@ class PostQueryServiceTest extends TestContainerConfig {
     @DisplayName("사용자 닉네임으로 게시물리스트를 조회해 요약 리스트로 반환한다.")
     @Test
     void searchByUserNicknameTest() {
-        User user = userJpaRepository.save(유저1);
+        User user = userRepository.save(유저1);
         postRepository.saveAll(게시물_모음);
 
         int pageSize = 20;

--- a/src/test/java/dev/backlog/domain/series/model/repository/SeriesRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/series/model/repository/SeriesRepositoryTest.java
@@ -1,6 +1,6 @@
 package dev.backlog.domain.series.model.repository;
 
-import dev.backlog.common.RepositoryTest;
+import dev.backlog.common.RepositoryTestConfig;
 import dev.backlog.domain.series.model.Series;
 import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
@@ -14,7 +14,7 @@ import static dev.backlog.common.fixture.EntityFixture.유저1;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-class SeriesRepositoryTest extends RepositoryTest {
+class SeriesRepositoryTest extends RepositoryTestConfig {
 
     @Autowired
     private SeriesRepository seriesRepository;

--- a/src/test/java/dev/backlog/domain/series/model/repository/SeriesRepositoryTest.java
+++ b/src/test/java/dev/backlog/domain/series/model/repository/SeriesRepositoryTest.java
@@ -2,8 +2,8 @@ package dev.backlog.domain.series.model.repository;
 
 import dev.backlog.common.RepositoryTestConfig;
 import dev.backlog.domain.series.model.Series;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,13 +20,13 @@ class SeriesRepositoryTest extends RepositoryTestConfig {
     private SeriesRepository seriesRepository;
 
     @Autowired
-    private UserJpaRepository userJpaRepository;
+    private UserRepository userRepository;
 
     @DisplayName("유저와 시리즈의 이름으로 시리즈를 조회할 수 있다.")
     @Test
     void getByUserAndNameTest() {
         //given
-        User savedUser = userJpaRepository.save(유저1());
+        User savedUser = userRepository.save(유저1());
         Series savedSeries = seriesRepository.save(시리즈1(savedUser));
 
         //when
@@ -40,7 +40,7 @@ class SeriesRepositoryTest extends RepositoryTestConfig {
     @Test
     void deleteAllTest() {
         //given
-        User savedUser = userJpaRepository.save(유저1());
+        User savedUser = userRepository.save(유저1());
         Series savedSeries = seriesRepository.save(시리즈1(savedUser));
 
         //when

--- a/src/test/java/dev/backlog/domain/user/service/UserServiceTest.java
+++ b/src/test/java/dev/backlog/domain/user/service/UserServiceTest.java
@@ -3,16 +3,14 @@ package dev.backlog.domain.user.service;
 import dev.backlog.domain.user.dto.UserDetailsResponse;
 import dev.backlog.domain.user.dto.UserResponse;
 import dev.backlog.domain.user.dto.UserUpdateRequest;
-import dev.backlog.domain.user.infrastructure.persistence.UserJpaRepository;
 import dev.backlog.domain.user.model.User;
+import dev.backlog.domain.user.model.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
 
 import static dev.backlog.common.fixture.EntityFixture.유저1;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,7 +24,7 @@ class UserServiceTest {
     private UserService userService;
 
     @Mock
-    private UserJpaRepository userJpaRepository;
+    private UserRepository userRepository;
 
     private User 유저1;
 
@@ -38,7 +36,7 @@ class UserServiceTest {
     @Test
     void findUserProfileTest() {
         String nickname = "닉네임";
-        when(userJpaRepository.findByNickname(유저1.getNickname())).thenReturn(Optional.of(유저1));
+        when(userRepository.getByNickname(유저1.getNickname())).thenReturn(유저1);
 
         UserResponse userProfile = userService.findUserProfile(nickname);
 
@@ -49,7 +47,7 @@ class UserServiceTest {
     void findMyProfileTest() {
         Long userId = 유저1.getId();
 
-        when(userJpaRepository.findById(유저1.getId())).thenReturn(Optional.of(유저1));
+        when(userRepository.getById(유저1.getId())).thenReturn(유저1);
 
         UserDetailsResponse myProfile = userService.findMyProfile(userId);
 
@@ -72,10 +70,10 @@ class UserServiceTest {
                 "새블로그제목"
         );
 
-        when(userJpaRepository.findById(유저1.getId())).thenReturn(Optional.of(유저1));
+        when(userRepository.getById(유저1.getId())).thenReturn(유저1);
 
         userService.updateProfile(updateRequest, 유저1.getId());
-        User updatedUser = userJpaRepository.findById(유저1.getId()).get();
+        User updatedUser = userRepository.getById(유저1.getId());
 
         assertAll(
                 () -> assertThat(updatedUser.getNickname()).isEqualTo(updateRequest.nickname()),


### PR DESCRIPTION
close: #85 
## 📄 Summary
>
DIP 원칙을 사용해 레포지토리의 변경을 서비스로 영향을 주지 않기 위해 분리

## 🍸 More
>
 유저 레포지토리 분리
 해시태그 레포지토리 분리
 포스트 해시태그 레포지토리 분리